### PR TITLE
MCP: authorize once, connect forever (v1.0.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## 2026-06-22 (v1.0.5 — MCP: authorize once, connect forever)
+- **fix(mcp): connecting an OAuth connector once now works indefinitely.** The `/token` exchange
+  used to delete the previous "OAuth connector" token on every connect (single slot), so any
+  reconnect or second client stranded an earlier session on a dead token → "connected but zero
+  tools". Now `mintOAuthToken` **never pre-deletes** (the in-use token survives a re-auth) and keeps
+  a small rolling window (`MAX_OAUTH_TOKENS`), so reconnects can't strand a client. Tokens stay
+  eternal (no expiry), so claude.ai authorizes once and never has to re-auth.
+- **fix(mcp): OAuth tokens are exempt from the manual 5-token cap.** Authorizing can no longer fail
+  with "limit reached"; the admin create-token cap counts manual tokens only (`McpTokenInfo.oauth`).
+- **docs:** corrected the stale `api/mcp/route.ts` header (it still described a single `MCP_TOKEN`
+  bearer) and the CLAUDE.md MCP section. `v1.0.5`.
+
 ## 2026-06-22 (v1.0.4 — full-width admin + non-wrapping table headers)
 - **feat(admin): admin pages now fill the browser width.** Dropped the `max-w-6xl` lock on the
   admin content column (no longer needed with the column/sidebar layout) — content is full width

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,15 +173,19 @@ are called out elsewhere (Caching, Typography, Conventions).
   `lib/` functions the admin routes use — same slug rules, revisions, soft-delete, revalidation,
   activity log. **Off unless the owner enables it** (Admin → Settings → Advanced toggle,
   `settings.mcp.enabled`); `verifyMcpToken` 401s every call while off.
-- **Auth = admin-managed tokens + thin OAuth.** Tokens are created in the admin (up to 5, named,
-  shown ONCE on creation — only the SHA-256 hash is kept in the `mcp_tokens` table; see
-  `lib/mcp/tokens.ts`). `verifyMcpToken` hashes the bearer + looks it up (and stamps `last_used_at`)
-  while the toggle is on. There is **no `MCP_TOKEN` env var.** Connectors that require OAuth run a
-  minimal OAuth 2.1 authorization-code + PKCE flow gated by the owner's NextAuth login
-  (`src/app/api/mcp/{authorize,token,register}` + `src/app/.well-known/oauth-*`); the `/token`
-  exchange **mints a managed token** (named "OAuth connector", replaced per connect) and returns it.
-  Codes are HMAC-signed (`MCP_OAUTH_SECRET` → falls back to `AUTH_SECRET`) in `lib/mcp/auth.ts`.
-  Token CRUD: owner-only `/api/mcp/tokens` (+ `/[id]`); UI in `components/admin/McpFields.tsx`.
+- **Auth = admin-managed tokens + thin OAuth.** Manual tokens are created in the admin (up to 5,
+  named, shown ONCE on creation — only the SHA-256 hash is kept in the `mcp_tokens` table; see
+  `lib/mcp/tokens.ts`). All tokens are **eternal (no expiry)**. `verifyMcpToken` hashes the bearer +
+  looks it up (and stamps `last_used_at`) while the toggle is on. There is **no `MCP_TOKEN` env var.**
+  Connectors that require OAuth run a minimal OAuth 2.1 authorization-code + PKCE flow gated by the
+  owner's NextAuth login (`src/app/api/mcp/{authorize,token,register}` + `src/app/.well-known/oauth-*`);
+  the `/token` exchange **mints an eternal token via `mintOAuthToken`** (named "OAuth connector") and
+  returns it. **OAuth tokens are exempt from the manual 5-cap and are NEVER pre-deleted** — a re-auth
+  keeps the connector's in-use token valid; only a small rolling window (`MAX_OAUTH_TOKENS`) is kept
+  so reconnects don't pile up. So **authorize once = works indefinitely** (no churn that strands a
+  client on a dead token; the old "replaced per connect" behavior is gone). Codes are HMAC-signed
+  (`MCP_OAUTH_SECRET` → falls back to `AUTH_SECRET`) in `lib/mcp/auth.ts`. Token CRUD: owner-only
+  `/api/mcp/tokens` (+ `/[id]`); UI in `components/admin/McpFields.tsx` (cap counts manual only).
 - **Tools** (`lib/mcp/tools.ts` posts/pages/taxonomy, `tools-library.ts` media/files/settings;
   results via `result.ts`). Content is Markdown verbatim — no HTML conversion. Deletes are soft
   (→ Trash). **`update_settings` exposes only a safe allowlist (title/description/showDescription)** —

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vibe**blog** (v1.0.4)
+# vibe**blog** (v1.0.5)
 
 An AI-operated personal blog platform. Write and publish from a multilingual admin
 UI. Text content (posts, pages, settings, metadata) lives in **Supabase Postgres**;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeblog",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "license": "MIT",
   "browserslist": [

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,8 +1,8 @@
 // Remote MCP endpoint (Streamable HTTP) at /api/mcp. Lets an MCP client (Claude,
 // ChatGPT, …) operate the blog with the SAME data layer as the admin UI. Gated by
-// a single full-access bearer (`MCP_TOKEN`); connectors that require OAuth obtain
-// that token via the thin OAuth layer (see /api/mcp/authorize|token|register and
-// the /.well-known/* metadata routes). Tools live in src/lib/mcp.
+// admin-managed tokens (see lib/mcp/tokens.ts) while the owner's toggle is on;
+// connectors that require OAuth mint an eternal token via the thin OAuth layer
+// (/api/mcp/authorize|token|register + /.well-known/* metadata). Tools in src/lib/mcp.
 
 import { createMcpHandler, withMcpAuth } from 'mcp-handler'
 import { registerTools } from '@/lib/mcp/tools'

--- a/src/app/api/mcp/token/route.ts
+++ b/src/app/api/mcp/token/route.ts
@@ -1,15 +1,12 @@
 // OAuth token endpoint (thin layer). Exchanges a valid authorization code + PKCE
-// verifier for an access token: we MINT a managed token (replacing this
-// connector's previous one so it doesn't pile up) and return it. Public client
-// (token_endpoint_auth_method=none); the code's signature + PKCE gate this.
+// verifier for an eternal access token (mintOAuthToken — never pre-deletes, so a
+// re-authorize can't kill the connector's in-use token; bounded rolling window).
+// Public client (token_endpoint_auth_method=none); the code's signature + PKCE gate this.
 
 import { verifyCode, mcpEnabled } from '@/lib/mcp/auth'
-import { createToken, deleteTokensByName } from '@/lib/mcp/tokens'
+import { mintOAuthToken } from '@/lib/mcp/tokens'
 
 export const dynamic = 'force-dynamic'
-
-// All OAuth-issued tokens share this name → one slot, refreshed on each connect.
-const OAUTH_TOKEN_NAME = 'OAuth connector'
 
 const CORS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
@@ -38,14 +35,13 @@ export async function POST(req: Request): Promise<Response> {
   if (!code || !redirectUri || !verifier || !verifyCode(code, redirectUri, verifier)) {
     return Response.json({ error: 'invalid_grant' }, { status: 400, headers: CORS })
   }
-  // Replace this connector's prior token, then mint a fresh one (full-access, no
-  // expiry — single owner). Fails if the 5-token cap is full and no OAuth slot frees.
-  await deleteTokensByName(OAUTH_TOKEN_NAME)
+  // Mint a fresh eternal token; old OAuth tokens stay valid (bounded window) so a
+  // re-auth never breaks the connector. Exempt from the manual cap → can't hit a limit.
   let minted
   try {
-    minted = await createToken(OAUTH_TOKEN_NAME)
+    minted = await mintOAuthToken()
   } catch {
-    return Response.json({ error: 'invalid_request', error_description: 'token limit reached — delete an MCP token in admin' }, { status: 400, headers: CORS })
+    return Response.json({ error: 'server_error', error_description: 'could not mint token' }, { status: 500, headers: CORS })
   }
   return Response.json({ access_token: minted.token, token_type: 'Bearer', scope: 'full' }, { status: 200, headers: CORS })
 }

--- a/src/components/admin/McpFields.tsx
+++ b/src/components/admin/McpFields.tsx
@@ -14,7 +14,7 @@ import { useToast } from '@/components/ui/Toast'
 import { formatDateTimeShort } from '@/lib/utils'
 import { useAdminT } from './I18nProvider'
 
-const MAX = 5
+const MAX = 5 // manual tokens only; OAuth-connector tokens are exempt
 
 export function McpFields({ mcp, onChange }: { mcp: McpSettings; onChange: (m: McpSettings) => void }) {
   const t = useAdminT()
@@ -110,7 +110,7 @@ export function McpFields({ mcp, onChange }: { mcp: McpSettings; onChange: (m: M
             <h3 className="text-sm font-semibold">{t.mcpTokensTitle}</h3>
             <p className="mt-0.5 text-xs text-neutral-400 dark:text-neutral-500">{t.mcpTokensHint}</p>
           </div>
-          <Button type="button" onClick={generate} disabled={pending || tokens.length >= MAX}>
+          <Button type="button" onClick={generate} disabled={pending || tokens.filter((tk) => !tk.oauth).length >= MAX}>
             {t.mcpGenerate}
           </Button>
         </div>

--- a/src/lib/mcp/tokens.ts
+++ b/src/lib/mcp/tokens.ts
@@ -6,8 +6,13 @@
 import { createHash, randomBytes } from 'node:crypto'
 import { db } from '@/lib/db'
 
-const MAX_TOKENS = 5
+const MAX_TOKENS = 5 // manual (admin-created) tokens only
 const TOKEN_PREFIX = 'vbmcp_'
+
+// OAuth-issued tokens share this name and are managed separately from manual ones:
+// exempt from MAX_TOKENS and kept as a small rolling window (mintOAuthToken).
+export const OAUTH_TOKEN_NAME = 'OAuth connector'
+const MAX_OAUTH_TOKENS = 2 // current + previous, so a re-auth never kills the in-use token
 
 // What the admin UI sees — never the secret itself.
 export type McpTokenInfo = {
@@ -16,6 +21,7 @@ export type McpTokenInfo = {
   prefix: string // short non-secret display hint, e.g. "vbmcp_AbCd"
   createdAt: string
   lastUsedAt: string | null
+  oauth: boolean // true = machine-issued via OAuth (not a manual admin token)
 }
 
 type TokenRow = { id: number; name: string; prefix: string; created_at: string; last_used_at: string | null }
@@ -28,6 +34,7 @@ const toInfo = (r: TokenRow): McpTokenInfo => ({
   prefix: r.prefix,
   createdAt: r.created_at,
   lastUsedAt: r.last_used_at,
+  oauth: r.name === OAUTH_TOKEN_NAME,
 })
 
 export const tokenLimit = (): number => MAX_TOKENS
@@ -41,17 +48,22 @@ export async function listTokens(): Promise<McpTokenInfo[]> {
   return ((data as TokenRow[] | null) ?? []).map(toInfo)
 }
 
-export async function countTokens(): Promise<number> {
-  const { count } = await db().from('mcp_tokens').select('id', { count: 'exact', head: true })
+// Count manual (admin-created) tokens — OAuth-issued ones are exempt from the cap.
+async function countManualTokens(): Promise<number> {
+  const { count } = await db().from('mcp_tokens').select('id', { count: 'exact', head: true }).neq('name', OAUTH_TOKEN_NAME)
   return count ?? 0
 }
 
-// Mint a named token. Returns the PLAINTEXT once (never stored again). Throws
-// 'token_limit' when MAX_TOKENS already exist.
-export async function createToken(name: string): Promise<{ token: string; info: McpTokenInfo }> {
-  if ((await countTokens()) >= MAX_TOKENS) throw new Error('token_limit')
+const newSecret = (): { token: string; prefix: string } => {
   const token = `${TOKEN_PREFIX}${randomBytes(24).toString('base64url')}`
-  const prefix = token.slice(0, 12)
+  return { token, prefix: token.slice(0, 12) }
+}
+
+// Mint a named MANUAL token. Returns the PLAINTEXT once (never stored again).
+// Throws 'token_limit' when MAX_TOKENS manual tokens already exist.
+export async function createToken(name: string): Promise<{ token: string; info: McpTokenInfo }> {
+  if ((await countManualTokens()) >= MAX_TOKENS) throw new Error('token_limit')
+  const { token, prefix } = newSecret()
   const { data, error } = await db()
     .from('mcp_tokens')
     .insert({ name: name.trim().slice(0, 80) || 'Token', token_hash: sha256(token), prefix })
@@ -61,13 +73,31 @@ export async function createToken(name: string): Promise<{ token: string; info: 
   return { token, info: toInfo(data as TokenRow) }
 }
 
-export async function deleteToken(id: number): Promise<void> {
-  await db().from('mcp_tokens').delete().eq('id', id)
+// Mint the OAuth-connector token (called by /api/mcp/token). NEVER pre-deletes, so a
+// connector's in-use token survives a re-authorize; afterwards prunes to the most
+// recent MAX_OAUTH_TOKENS so reconnects can't pile up. Exempt from the manual cap →
+// authorizing never fails with "limit reached". Eternal (no expiry) → connect once.
+export async function mintOAuthToken(): Promise<{ token: string; info: McpTokenInfo }> {
+  const { token, prefix } = newSecret()
+  const { data, error } = await db()
+    .from('mcp_tokens')
+    .insert({ name: OAUTH_TOKEN_NAME, token_hash: sha256(token), prefix })
+    .select('id,name,prefix,created_at,last_used_at')
+    .single()
+  if (error) throw new Error(`mintOAuthToken: ${error.message}`)
+  const { data: stale } = await db()
+    .from('mcp_tokens')
+    .select('id')
+    .eq('name', OAUTH_TOKEN_NAME)
+    .order('created_at', { ascending: false })
+    .range(MAX_OAUTH_TOKENS, 1000)
+  const ids = ((stale as { id: number }[] | null) ?? []).map((r) => r.id)
+  if (ids.length) await db().from('mcp_tokens').delete().in('id', ids)
+  return { token, info: toInfo(data as TokenRow) }
 }
 
-// Remove every token with this name (used to replace a connector's prior token).
-export async function deleteTokensByName(name: string): Promise<void> {
-  await db().from('mcp_tokens').delete().eq('name', name)
+export async function deleteToken(id: number): Promise<void> {
+  await db().from('mcp_tokens').delete().eq('id', id)
 }
 
 // Verify a presented bearer: hash + lookup. On a match, stamp last_used_at and


### PR DESCRIPTION
Fixes the "connected but zero tools" symptom on the vibeblog MCP connector.

**Root cause:** `/api/mcp/token` deleted the previous `OAuth connector` token on every connect (single slot), so a reconnect/second client stranded an earlier session on a dead token.

**Fix:**
- `mintOAuthToken()` never pre-deletes (in-use token survives a re-auth); keeps a small rolling window so reconnects can't pile up.
- Tokens stay eternal → authorize once, never re-auth.
- OAuth tokens exempt from the manual 5-token cap; admin cap counts manual only (`McpTokenInfo.oauth`).
- Stale comments fixed.

Verified locally: `tsc` / `lint` / `build` all exit 0. No DB migration needed; existing tokens stay valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)