### PR TITLE
MCP token list always fresh (v1.0.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 2026-06-22 (v1.0.6 — MCP token list always reflects reality)
+- **fix(admin): the MCP token list no longer shows a stale snapshot.** It loaded only on mount, so
+  connecting/disconnecting in Claude (out-of-band) left the admin list wrong — "can't delete the old
+  one", "don't see the new one". It now **refetches on tab focus / visibility change** and has a
+  manual **Refresh** button, so the owner always sees and can revoke every live token/connection.
+- **fix(mcp): prune the OAuth rolling window by `id` (monotonic PK), not `created_at`** — removes a
+  tie risk where a freshly minted token could be pruned. `v1.0.6`.
+- Note: deleting a connector's token revokes that session; the connector can only re-appear if the
+  owner re-approves OAuth (authorize is gated by the owner's login). To fully stop access, also
+  disconnect in Claude or turn the MCP toggle off.
+
 ## 2026-06-22 (v1.0.5 — MCP: authorize once, connect forever)
 - **fix(mcp): connecting an OAuth connector once now works indefinitely.** The `/token` exchange
   used to delete the previous "OAuth connector" token on every connect (single slot), so any

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vibe**blog** (v1.0.5)
+# vibe**blog** (v1.0.6)
 
 An AI-operated personal blog platform. Write and publish from a multilingual admin
 UI. Text content (posts, pages, settings, metadata) lives in **Supabase Postgres**;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeblog",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "license": "MIT",
   "browserslist": [

--- a/src/components/admin/McpFields.tsx
+++ b/src/components/admin/McpFields.tsx
@@ -44,6 +44,19 @@ export function McpFields({ mcp, onChange }: { mcp: McpSettings; onChange: (m: M
       .catch(() => {})
   }, [])
 
+  // Refetch whenever the owner returns to this tab — connectors are created/revoked
+  // out-of-band (in Claude), so the list must re-sync or it shows a stale snapshot
+  // ("I reconnected but don't see it"). Listeners only, so no setState in the body.
+  useEffect(() => {
+    const onFocus = () => { if (document.visibilityState === 'visible') refresh() }
+    window.addEventListener('focus', onFocus)
+    document.addEventListener('visibilitychange', onFocus)
+    return () => {
+      window.removeEventListener('focus', onFocus)
+      document.removeEventListener('visibilitychange', onFocus)
+    }
+  }, [refresh])
+
   async function generate() {
     const name = prompt(t.mcpNamePrompt)?.trim()
     if (!name) return
@@ -110,9 +123,18 @@ export function McpFields({ mcp, onChange }: { mcp: McpSettings; onChange: (m: M
             <h3 className="text-sm font-semibold">{t.mcpTokensTitle}</h3>
             <p className="mt-0.5 text-xs text-neutral-400 dark:text-neutral-500">{t.mcpTokensHint}</p>
           </div>
-          <Button type="button" onClick={generate} disabled={pending || tokens.filter((tk) => !tk.oauth).length >= MAX}>
-            {t.mcpGenerate}
-          </Button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => refresh()}
+              className="rounded-lg px-2.5 py-1.5 text-xs text-neutral-500 hover:bg-neutral-100 hover:text-neutral-900 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-white"
+            >
+              {t.mcpRefresh}
+            </button>
+            <Button type="button" onClick={generate} disabled={pending || tokens.filter((tk) => !tk.oauth).length >= MAX}>
+              {t.mcpGenerate}
+            </Button>
+          </div>
         </div>
 
         {/* The just-created plaintext token, shown ONCE. */}

--- a/src/lib/mcp/tokens.ts
+++ b/src/lib/mcp/tokens.ts
@@ -89,7 +89,7 @@ export async function mintOAuthToken(): Promise<{ token: string; info: McpTokenI
     .from('mcp_tokens')
     .select('id')
     .eq('name', OAUTH_TOKEN_NAME)
-    .order('created_at', { ascending: false })
+    .order('id', { ascending: false }) // monotonic PK → the just-minted row is always newest, never pruned
     .range(MAX_OAUTH_TOKENS, 1000)
   const ids = ((stale as { id: number }[] | null) ?? []).map((r) => r.id)
   if (ids.length) await db().from('mcp_tokens').delete().in('id', ids)

--- a/src/locales/admin/de.ts
+++ b/src/locales/admin/de.ts
@@ -310,6 +310,7 @@ const de = {
   mcpColName: 'Name',
   mcpColCreated: 'Erstellt',
   mcpColLastUsed: 'Zuletzt benutzt',
+  mcpRefresh: 'Aktualisieren',
   mcpNeverUsed: 'Nie',
   mcpConfirmDelete: 'Diesen Token löschen? Jeder Client, der ihn nutzt, funktioniert nicht mehr.',
   mcpTokenDeleted: 'Token gelöscht',

--- a/src/locales/admin/en.ts
+++ b/src/locales/admin/en.ts
@@ -310,6 +310,7 @@ const en = {
   mcpColName: 'Name',
   mcpColCreated: 'Created',
   mcpColLastUsed: 'Last used',
+  mcpRefresh: 'Refresh',
   mcpNeverUsed: 'Never',
   mcpConfirmDelete: 'Delete this token? Any client using it will stop working.',
   mcpTokenDeleted: 'Token deleted',

--- a/src/locales/admin/ja.ts
+++ b/src/locales/admin/ja.ts
@@ -310,6 +310,7 @@ const ja = {
   mcpColName: '名前',
   mcpColCreated: '作成日',
   mcpColLastUsed: '最終使用',
+  mcpRefresh: '更新',
   mcpNeverUsed: '未使用',
   mcpConfirmDelete: 'このトークンを削除しますか？使用中のクライアントは動作しなくなります。',
   mcpTokenDeleted: 'トークンを削除しました',

--- a/src/locales/admin/ko.ts
+++ b/src/locales/admin/ko.ts
@@ -310,6 +310,7 @@ const ko = {
   mcpColName: '이름',
   mcpColCreated: '생성일',
   mcpColLastUsed: '마지막 사용',
+  mcpRefresh: '새로고침',
   mcpNeverUsed: '사용 안 함',
   mcpConfirmDelete: '이 토큰을 삭제할까요? 이를 사용하는 모든 클라이언트가 작동을 멈춥니다.',
   mcpTokenDeleted: '토큰을 삭제했습니다',

--- a/src/locales/admin/vi.ts
+++ b/src/locales/admin/vi.ts
@@ -310,6 +310,7 @@ const vi = {
   mcpColName: 'Tên',
   mcpColCreated: 'Tạo lúc',
   mcpColLastUsed: 'Dùng gần nhất',
+  mcpRefresh: 'Làm mới',
   mcpNeverUsed: 'Chưa dùng',
   mcpConfirmDelete: 'Xoá token này? Mọi client đang dùng nó sẽ ngừng hoạt động.',
   mcpTokenDeleted: 'Đã xoá token',

--- a/src/locales/admin/zh.ts
+++ b/src/locales/admin/zh.ts
@@ -310,6 +310,7 @@ const zh = {
   mcpColName: '名称',
   mcpColCreated: '创建时间',
   mcpColLastUsed: '最近使用',
+  mcpRefresh: '刷新',
   mcpNeverUsed: '从未使用',
   mcpConfirmDelete: '删除此令牌？正在使用它的客户端将停止工作。',
   mcpTokenDeleted: '已删除令牌',

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -364,6 +364,7 @@ export type AdminStrings = {
   mcpColName: string
   mcpColCreated: string
   mcpColLastUsed: string
+  mcpRefresh: string
   mcpNeverUsed: string
   mcpConfirmDelete: string
   mcpTokenDeleted: string


### PR DESCRIPTION
The admin MCP token list only loaded on mount, so connecting/disconnecting in Claude (out-of-band) left it showing a stale snapshot — hence "can't delete the old token" / "don't see the new connector".

- Refetch on tab focus / visibilitychange + a manual **Refresh** button → the owner always sees and can revoke every live token.
- New i18n key `mcpRefresh` across all 6 admin locales.
- OAuth rolling-window prune now orders by `id` (monotonic PK) not `created_at`, removing a tie risk that could prune a freshly minted token.

Verified: `tsc` / `lint` / `build` all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)