### PR TITLE
MCP: admin is the sole authority over a connection (v1.0.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 2026-06-22 (v1.0.7 — MCP: admin is the sole authority over a connection)
+- **change(mcp): OAuth tokens are NEVER auto-deleted.** Removed the rolling-window prune
+  (`MAX_OAUTH_TOKENS`) — the system no longer removes connections behind the owner's back.
+  Lifecycle rule now matches intent: a connection **persists forever** (eternal token, no expiry,
+  no prune) until the **owner deletes it in the admin**; an admin delete is final unless the owner
+  re-authorizes. Deleting the connector in Claude alone just lets it re-authorize (a new token row;
+  the old one persists until the owner removes it). `v1.0.7`.
+
 ## 2026-06-22 (v1.0.6 — MCP token list always reflects reality)
 - **fix(admin): the MCP token list no longer shows a stale snapshot.** It loaded only on mount, so
   connecting/disconnecting in Claude (out-of-band) left the admin list wrong — "can't delete the old

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,10 +180,12 @@ are called out elsewhere (Caching, Typography, Conventions).
   Connectors that require OAuth run a minimal OAuth 2.1 authorization-code + PKCE flow gated by the
   owner's NextAuth login (`src/app/api/mcp/{authorize,token,register}` + `src/app/.well-known/oauth-*`);
   the `/token` exchange **mints an eternal token via `mintOAuthToken`** (named "OAuth connector") and
-  returns it. **OAuth tokens are exempt from the manual 5-cap and are NEVER pre-deleted** — a re-auth
-  keeps the connector's in-use token valid; only a small rolling window (`MAX_OAUTH_TOKENS`) is kept
-  so reconnects don't pile up. So **authorize once = works indefinitely** (no churn that strands a
-  client on a dead token; the old "replaced per connect" behavior is gone). Codes are HMAC-signed
+  returns it. **OAuth tokens are exempt from the manual 5-cap and are NEVER auto-deleted.**
+  **Lifecycle rule: the admin is the SOLE authority over a connection** — a token persists forever
+  (no expiry, no prune) until the OWNER deletes it in the admin; deleting the connector in Claude
+  alone just lets it re-authorize (a new token). So authorize once = stays connected indefinitely,
+  and an admin delete is final unless the owner re-authorizes. (A reconnect mints a new row; the
+  prior one persists until the owner removes it — the admin lists/deletes them all.) Codes are HMAC-signed
   (`MCP_OAUTH_SECRET` → falls back to `AUTH_SECRET`) in `lib/mcp/auth.ts`. Token CRUD: owner-only
   `/api/mcp/tokens` (+ `/[id]`); UI in `components/admin/McpFields.tsx` (cap counts manual only).
 - **Tools** (`lib/mcp/tools.ts` posts/pages/taxonomy, `tools-library.ts` media/files/settings;

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vibe**blog** (v1.0.6)
+# vibe**blog** (v1.0.7)
 
 An AI-operated personal blog platform. Write and publish from a multilingual admin
 UI. Text content (posts, pages, settings, metadata) lives in **Supabase Postgres**;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeblog",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "license": "MIT",
   "browserslist": [

--- a/src/app/api/mcp/token/route.ts
+++ b/src/app/api/mcp/token/route.ts
@@ -1,7 +1,7 @@
 // OAuth token endpoint (thin layer). Exchanges a valid authorization code + PKCE
-// verifier for an eternal access token (mintOAuthToken — never pre-deletes, so a
-// re-authorize can't kill the connector's in-use token; bounded rolling window).
-// Public client (token_endpoint_auth_method=none); the code's signature + PKCE gate this.
+// verifier for an eternal access token (mintOAuthToken — never deletes any token, so
+// a connection persists until the owner removes it in the admin). Public client
+// (token_endpoint_auth_method=none); the code's signature + PKCE gate this.
 
 import { verifyCode, mcpEnabled } from '@/lib/mcp/auth'
 import { mintOAuthToken } from '@/lib/mcp/tokens'
@@ -35,8 +35,8 @@ export async function POST(req: Request): Promise<Response> {
   if (!code || !redirectUri || !verifier || !verifyCode(code, redirectUri, verifier)) {
     return Response.json({ error: 'invalid_grant' }, { status: 400, headers: CORS })
   }
-  // Mint a fresh eternal token; old OAuth tokens stay valid (bounded window) so a
-  // re-auth never breaks the connector. Exempt from the manual cap → can't hit a limit.
+  // Mint a fresh eternal token; nothing else is touched (old tokens persist until the
+  // owner deletes them in the admin). Exempt from the manual cap → can't hit a limit.
   let minted
   try {
     minted = await mintOAuthToken()

--- a/src/lib/mcp/tokens.ts
+++ b/src/lib/mcp/tokens.ts
@@ -10,9 +10,10 @@ const MAX_TOKENS = 5 // manual (admin-created) tokens only
 const TOKEN_PREFIX = 'vbmcp_'
 
 // OAuth-issued tokens share this name and are managed separately from manual ones:
-// exempt from MAX_TOKENS and kept as a small rolling window (mintOAuthToken).
+// exempt from MAX_TOKENS. They are NEVER auto-deleted — a connection persists until
+// the owner deletes it in the admin (the admin is the sole authority over a
+// connection's lifecycle); deleting from Claude alone just lets it re-authorize.
 export const OAUTH_TOKEN_NAME = 'OAuth connector'
-const MAX_OAUTH_TOKENS = 2 // current + previous, so a re-auth never kills the in-use token
 
 // What the admin UI sees — never the secret itself.
 export type McpTokenInfo = {
@@ -73,10 +74,10 @@ export async function createToken(name: string): Promise<{ token: string; info: 
   return { token, info: toInfo(data as TokenRow) }
 }
 
-// Mint the OAuth-connector token (called by /api/mcp/token). NEVER pre-deletes, so a
-// connector's in-use token survives a re-authorize; afterwards prunes to the most
-// recent MAX_OAUTH_TOKENS so reconnects can't pile up. Exempt from the manual cap →
-// authorizing never fails with "limit reached". Eternal (no expiry) → connect once.
+// Mint the OAuth-connector token (called by /api/mcp/token). NEVER deletes any token
+// (the in-use one survives a re-authorize; nothing auto-prunes — the owner alone
+// removes connections in the admin). Exempt from the manual cap → authorizing never
+// fails with "limit reached". Eternal (no expiry) → connect once, stays connected.
 export async function mintOAuthToken(): Promise<{ token: string; info: McpTokenInfo }> {
   const { token, prefix } = newSecret()
   const { data, error } = await db()
@@ -85,14 +86,6 @@ export async function mintOAuthToken(): Promise<{ token: string; info: McpTokenI
     .select('id,name,prefix,created_at,last_used_at')
     .single()
   if (error) throw new Error(`mintOAuthToken: ${error.message}`)
-  const { data: stale } = await db()
-    .from('mcp_tokens')
-    .select('id')
-    .eq('name', OAUTH_TOKEN_NAME)
-    .order('id', { ascending: false }) // monotonic PK → the just-minted row is always newest, never pruned
-    .range(MAX_OAUTH_TOKENS, 1000)
-  const ids = ((stale as { id: number }[] | null) ?? []).map((r) => r.id)
-  if (ids.length) await db().from('mcp_tokens').delete().in('id', ids)
   return { token, info: toInfo(data as TokenRow) }
 }
 


### PR DESCRIPTION
Removes the OAuth rolling-window prune so the system never deletes a connection behind the owner's back.

**Lifecycle rule (matches the owner's stated principle):**
- A connection persists forever (eternal token, no expiry, no prune) until the **owner deletes it in the admin**.
- An admin delete is final unless the owner re-authorizes.
- Deleting only in Claude just lets it re-authorize (new token row; the old persists until removed in admin).

Verified: `tsc` / `lint` / `build` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)