### PR TITLE
Fix stale admin lists (real delete bug) + 5xx error pages (v1.0.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CHANGELOG
 
+## 2026-06-22 (v1.0.8 — fix stale admin lists + 5xx/error pages)
+- **fix(admin): admin list endpoints showed STALE data (the real "can't delete a token" bug).**
+  `db()` GET reads are Data-Cache-eligible (tag `db`, 1h). The admin client-fetched list routes
+  weren't `force-dynamic`, so after a delete/upload the cached list still showed the old rows — the
+  MCP token list kept showing a just-deleted token, so re-clicking Delete was a no-op on a dead id
+  (only toggling MCP off, which calls `revalidateTag('db')`, refreshed it). Marked **`force-dynamic`**
+  on every owner-only list route so they always read live: `mcp/tokens`, `files`, `media`,
+  `media/unused`, `posts/[slug]/revisions`. Deleting a connection from the admin now takes effect
+  immediately, as intended.
+- **fix(admin): corrected `api/media` GET header comment** (said "public read" — it is owner-only).
+- **feat: 5xx / error pages now match the 404.** Added `error.tsx` (per-segment) + `(blog)/error.tsx`
+  (keeps the public shell) + `global-error.tsx` (root-layout failures), all rendering a shared
+  `ErrorView` styled identically to the 404 (number + title + text + Try again / Back home, on theme
+  tokens). New locale keys `errorTitle`/`errorText`/`tryAgain` in all 6 languages. `v1.0.8`.
+
 ## 2026-06-22 (v1.0.7 — MCP: admin is the sole authority over a connection)
 - **change(mcp): OAuth tokens are NEVER auto-deleted.** Removed the rolling-window prune
   (`MAX_OAUTH_TOKENS`) — the system no longer removes connections behind the owner's back.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vibe**blog** (v1.0.7)
+# vibe**blog** (v1.0.8)
 
 An AI-operated personal blog platform. Write and publish from a multilingual admin
 UI. Text content (posts, pages, settings, metadata) lives in **Supabase Postgres**;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeblog",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "license": "MIT",
   "browserslist": [

--- a/src/app/(blog)/error.tsx
+++ b/src/app/(blog)/error.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+// Runtime errors inside the public blog shell → a 500-style page that keeps the
+// (blog) header/footer and matches the 404 exactly.
+import { useEffect } from 'react'
+import { ErrorView } from '@/components/ErrorView'
+
+export default function BlogError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => { console.error(error) }, [error])
+  return <ErrorView reset={reset} />
+}

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -6,6 +6,10 @@ import type { NextRequest } from 'next/server'
 import { getFiles } from '@/lib/files'
 import { ok, fail, logRequest, logError, requireOwner } from '@/lib/api'
 
+// Admin-only live data: db() GET reads are Data-Cache-eligible (tag 'db', 1h), so
+// without this the list stays stale after an upload/delete. Force a live read.
+export const dynamic = 'force-dynamic'
+
 export async function GET(req: NextRequest): Promise<Response> {
   const start = Date.now()
   try {

--- a/src/app/api/mcp/tokens/route.ts
+++ b/src/app/api/mcp/tokens/route.ts
@@ -7,6 +7,11 @@ import { listTokens, createToken } from '@/lib/mcp/tokens'
 import { logActivity } from '@/lib/activity'
 import { ok, fail, logRequest, logError, requireOwner } from '@/lib/api'
 
+// Admin-only live data: the GET list must reflect the DB immediately (creates +
+// OAuth mints + deletes happen out-of-band). Without this, db() GET reads are
+// Data-Cache-eligible (tag 'db', 1h) → the list shows deleted/stale tokens.
+export const dynamic = 'force-dynamic'
+
 export async function GET(req: NextRequest): Promise<Response> {
   const start = Date.now()
   try {

--- a/src/app/api/media/route.ts
+++ b/src/app/api/media/route.ts
@@ -1,8 +1,12 @@
-// GET /api/media -> media manifest (public read)
+// GET /api/media -> media manifest (owner only; the admin media library reads it).
 
 import type { NextRequest } from 'next/server'
 import { getMedia } from '@/lib/media'
 import { ok, fail, logRequest, logError, requireOwner } from '@/lib/api'
+
+// Admin-only live data: db() GET reads are Data-Cache-eligible (tag 'db', 1h), so
+// without this the library stays stale after an upload/delete. Force a live read.
+export const dynamic = 'force-dynamic'
 
 export async function GET(req: NextRequest): Promise<Response> {
   const start = Date.now()

--- a/src/app/api/media/unused/route.ts
+++ b/src/app/api/media/unused/route.ts
@@ -6,6 +6,10 @@ import type { NextRequest } from 'next/server'
 import { findUnusedMedia } from '@/lib/media-usage'
 import { ok, fail, logRequest, logError, requireOwner } from '@/lib/api'
 
+// Admin-only live audit: db() GET reads are Data-Cache-eligible (tag 'db', 1h);
+// force a live read so the "unused" set reflects the current DB.
+export const dynamic = 'force-dynamic'
+
 // Reads every post/page body plus revision snapshots to collect references.
 export const maxDuration = 60
 

--- a/src/app/api/posts/[slug]/revisions/route.ts
+++ b/src/app/api/posts/[slug]/revisions/route.ts
@@ -5,6 +5,10 @@ import type { NextRequest } from 'next/server'
 import { getRevisions } from '@/lib/revisions'
 import { ok, fail, logRequest, logError, requireOwner } from '@/lib/api'
 
+// Admin-only live data: db() GET reads are Data-Cache-eligible (tag 'db', 1h);
+// force a live read so the time-machine list shows the latest snapshots.
+export const dynamic = 'force-dynamic'
+
 export async function GET(req: NextRequest, ctx: RouteContext<'/api/posts/[slug]/revisions'>): Promise<Response> {
   const start = Date.now()
   try {

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+// Catches runtime errors in any non-(blog) segment (e.g. admin) → a 500-style page
+// styled like the 404. (blog) errors are caught by (blog)/error.tsx so they keep
+// the public shell; root-layout failures fall back to global-error.tsx.
+import { useEffect } from 'react'
+import { ErrorView } from '@/components/ErrorView'
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => { console.error(error) }, [error])
+  return <ErrorView reset={reset} />
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+// Last resort: catches errors in the ROOT layout itself, so it must render its own
+// <html>/<body> and pull in globals.css (the failed layout provides neither). Uses
+// the default palette/typography from globals.css; language can't be resolved here
+// (the layout that sets <html lang> failed), so ErrorView falls back to English.
+import './globals.css'
+import { ErrorView } from '@/components/ErrorView'
+
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  console.error(error)
+  return (
+    <html lang="en" className="h-full">
+      <body className="min-h-full">
+        <ErrorView reset={reset} />
+      </body>
+    </html>
+  )
+}

--- a/src/components/ErrorView.tsx
+++ b/src/components/ErrorView.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+// Shared error UI — visually identical to the 404 ((blog)/not-found.tsx): big
+// number, title, text, actions, all on theme tokens. Used by every error boundary.
+// Client component (boundaries must be), so the language is read from <html lang>
+// (set by the root layout) with an English fallback.
+import Link from 'next/link'
+import { useState } from 'react'
+import { t } from '@/lib/i18n'
+import { isSiteLang } from '@/locales/langs'
+import type { SiteLang } from '@/types'
+
+export function ErrorView({ code = '500', reset }: { code?: string; reset?: () => void }) {
+  // Read the active language once from <html lang> (set by the root layout); SSR has
+  // no document → English. Lazy init keeps it a single read with no setState/effect.
+  const [lang] = useState<SiteLang>(() => {
+    if (typeof document === 'undefined') return 'en'
+    const l = document.documentElement.lang
+    return isSiteLang(l) ? l : 'en'
+  })
+  const s = t(lang)
+  return (
+    <div className="py-24 text-center">
+      <p className="text-6xl font-bold tracking-tight text-heading">{code}</p>
+      <h1 className="mt-4 fs-h3 font-semibold">{s.errorTitle}</h1>
+      <p className="mt-2 text-meta">{s.errorText}</p>
+      <div className="mt-8 flex items-center justify-center gap-5">
+        {reset && (
+          <button type="button" onClick={reset} className="t-small font-medium text-link underline underline-offset-4">
+            {s.tryAgain}
+          </button>
+        )}
+        <Link href="/" className="t-small font-medium text-link underline underline-offset-4">{s.backHome}</Link>
+      </div>
+    </div>
+  )
+}

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -24,6 +24,9 @@ const de = {
   relatedTitle: 'Ähnliche Beiträge',
   notFoundTitle: 'Seite nicht gefunden',
   notFoundText: 'Die gesuchte Seite existiert nicht oder wurde verschoben.',
+  errorTitle: 'Etwas ist schiefgelaufen',
+  errorText: 'Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut.',
+  tryAgain: 'Erneut versuchen',
   backHome: 'Zur Startseite',
   backToTop: 'Nach oben',
 } satisfies Dict

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -24,6 +24,9 @@ const en = {
   relatedTitle: 'Related posts',
   notFoundTitle: 'Page not found',
   notFoundText: 'The page you are looking for does not exist or has moved.',
+  errorTitle: 'Something went wrong',
+  errorText: 'An unexpected error occurred. Please try again.',
+  tryAgain: 'Try again',
   backHome: 'Back home',
   backToTop: 'Back to top',
 } satisfies Dict

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -24,6 +24,9 @@ const ja = {
   relatedTitle: '関連記事',
   notFoundTitle: 'ページが見つかりません',
   notFoundText: 'お探しのページは存在しないか、移動されました。',
+  errorTitle: '問題が発生しました',
+  errorText: '予期しないエラーが発生しました。もう一度お試しください。',
+  tryAgain: '再試行',
   backHome: 'ホームに戻る',
   backToTop: 'トップへ戻る',
 } satisfies Dict

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -24,6 +24,9 @@ const ko = {
   relatedTitle: '관련 게시물',
   notFoundTitle: '페이지를 찾을 수 없습니다',
   notFoundText: '찾으시는 페이지가 존재하지 않거나 이동되었습니다.',
+  errorTitle: '문제가 발생했습니다',
+  errorText: '예기치 않은 오류가 발생했습니다. 다시 시도해 주세요.',
+  tryAgain: '다시 시도',
   backHome: '홈으로',
   backToTop: '맨 위로',
 } satisfies Dict

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -25,6 +25,9 @@ export type Dict = {
   relatedTitle: string
   notFoundTitle: string
   notFoundText: string
+  errorTitle: string
+  errorText: string
+  tryAgain: string
   backHome: string
   backToTop: string
 }

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -24,6 +24,9 @@ const vi = {
   relatedTitle: 'Bài viết liên quan',
   notFoundTitle: 'Không tìm thấy trang',
   notFoundText: 'Trang bạn tìm không tồn tại hoặc đã được dời đi.',
+  errorTitle: 'Đã xảy ra lỗi',
+  errorText: 'Có lỗi không mong muốn. Vui lòng thử lại.',
+  tryAgain: 'Thử lại',
   backHome: 'Về trang chủ',
   backToTop: 'Lên đầu trang',
 } satisfies Dict

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -24,6 +24,9 @@ const zh = {
   relatedTitle: '相关文章',
   notFoundTitle: '页面未找到',
   notFoundText: '您查找的页面不存在或已被移动。',
+  errorTitle: '出错了',
+  errorText: '发生了意外错误，请重试。',
+  tryAgain: '重试',
   backHome: '返回首页',
   backToTop: '回到顶部',
 } satisfies Dict


### PR DESCRIPTION
## The real "can't delete a token" bug
`db()` GET reads are Data-Cache-eligible (tag `db`, 1h). The admin client-fetched list routes weren't `force-dynamic`, so after a delete the **cached** list still showed the deleted row → re-clicking Delete was a no-op on a dead id. Only toggling MCP off "fixed" it (saving settings calls `revalidateTag('db')`). Confirmed via the activity log (delete id=1 four times).

**Fix:** `force-dynamic` on every owner-only list route so they always read live:
`mcp/tokens`, `files`, `media`, `media/unused`, `posts/[slug]/revisions`. Admin deletes now take effect immediately — matching the principle "admin is the sole authority over a connection."

## Error pages match the 404
`error.tsx` (per-segment) + `(blog)/error.tsx` (keeps the public shell) + `global-error.tsx` (root-layout failures), all via a shared `ErrorView` styled identically to the 404. New locale keys in all 6 languages.

Also fixed a misleading "public read" comment on `api/media` GET (it's owner-only).

Verified: `tsc` / `lint` / `build` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)