### PR TITLE
Unify all error pages to one look (v1.0.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 2026-06-22 (v1.0.9 — every error page shares one look)
+- **refactor: all error/edge screens now route through ONE `ErrorScreen` component** so they can't
+  drift. The public 404, the 5xx boundaries (`ErrorView`), and a new **admin 404**
+  (`app/admin/not-found.tsx`, for unmatched admin URLs) all render the identical layout (number +
+  title + text + actions on theme tokens) — fully consistent per request. Shared `ERROR_LINK` class.
+- The public 404 keeps the blog header/footer; the admin 404 renders in the admin shell. (Other 4xx
+  like 401/403 stay auth redirects/JSON by design, not pages.) `v1.0.9`.
+
 ## 2026-06-22 (v1.0.8 — fix stale admin lists + 5xx/error pages)
 - **fix(admin): admin list endpoints showed STALE data (the real "can't delete a token" bug).**
   `db()` GET reads are Data-Cache-eligible (tag `db`, 1h). The admin client-fetched list routes

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vibe**blog** (v1.0.8)
+# vibe**blog** (v1.0.9)
 
 An AI-operated personal blog platform. Write and publish from a multilingual admin
 UI. Text content (posts, pages, settings, metadata) lives in **Supabase Postgres**;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeblog",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "license": "MIT",
   "browserslist": [

--- a/src/app/admin/not-found.tsx
+++ b/src/app/admin/not-found.tsx
@@ -1,16 +1,16 @@
-// 404 inside the blog shell (header + footer from the (blog) layout). Shares the
-// ErrorScreen look with every other error page.
+// 404 for unmatched admin URLs — renders inside the admin shell, same ErrorScreen
+// look as the public 404 so every error page is consistent.
 import Link from 'next/link'
 import { getSettings } from '@/lib/settings'
 import { t } from '@/lib/i18n'
 import { ErrorScreen, ERROR_LINK } from '@/components/ErrorScreen'
 
-export default async function NotFound() {
+export default async function AdminNotFound() {
   const { language } = await getSettings()
   const s = t(language)
   return (
     <ErrorScreen code="404" title={s.notFoundTitle} text={s.notFoundText}>
-      <Link href="/" className={ERROR_LINK}>{s.backHome}</Link>
+      <Link href="/admin" className={ERROR_LINK}>{s.backHome}</Link>
     </ErrorScreen>
   )
 }

--- a/src/components/ErrorScreen.tsx
+++ b/src/components/ErrorScreen.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react'
+
+// THE single source of the error-page look. Every error/edge screen routes through
+// this so they can never drift: the public 404 (not-found), the admin 404, and the
+// 5xx boundaries (ErrorView). Server-safe (no hooks) so server and client callers
+// share it. `children` = the action links/buttons (styled with ERROR_LINK).
+export const ERROR_LINK = 't-small font-medium text-link underline underline-offset-4'
+
+export function ErrorScreen({ code, title, text, children }: {
+  code: string
+  title: string
+  text: string
+  children: ReactNode
+}) {
+  return (
+    <div className="py-24 text-center">
+      <p className="text-6xl font-bold tracking-tight text-heading">{code}</p>
+      <h1 className="mt-4 fs-h3 font-semibold">{title}</h1>
+      <p className="mt-2 text-meta">{text}</p>
+      <div className="mt-8 flex items-center justify-center gap-5">{children}</div>
+    </div>
+  )
+}

--- a/src/components/ErrorView.tsx
+++ b/src/components/ErrorView.tsx
@@ -1,18 +1,16 @@
 'use client'
 
-// Shared error UI — visually identical to the 404 ((blog)/not-found.tsx): big
-// number, title, text, actions, all on theme tokens. Used by every error boundary.
-// Client component (boundaries must be), so the language is read from <html lang>
-// (set by the root layout) with an English fallback.
+// Client wrapper of ErrorScreen for the error boundaries (which must be client).
+// Language is read once from <html lang> (set by the root layout); SSR has no
+// document → English. Same look as the 404 via the shared ErrorScreen.
 import Link from 'next/link'
 import { useState } from 'react'
 import { t } from '@/lib/i18n'
 import { isSiteLang } from '@/locales/langs'
 import type { SiteLang } from '@/types'
+import { ErrorScreen, ERROR_LINK } from '@/components/ErrorScreen'
 
 export function ErrorView({ code = '500', reset }: { code?: string; reset?: () => void }) {
-  // Read the active language once from <html lang> (set by the root layout); SSR has
-  // no document → English. Lazy init keeps it a single read with no setState/effect.
   const [lang] = useState<SiteLang>(() => {
     if (typeof document === 'undefined') return 'en'
     const l = document.documentElement.lang
@@ -20,18 +18,11 @@ export function ErrorView({ code = '500', reset }: { code?: string; reset?: () =
   })
   const s = t(lang)
   return (
-    <div className="py-24 text-center">
-      <p className="text-6xl font-bold tracking-tight text-heading">{code}</p>
-      <h1 className="mt-4 fs-h3 font-semibold">{s.errorTitle}</h1>
-      <p className="mt-2 text-meta">{s.errorText}</p>
-      <div className="mt-8 flex items-center justify-center gap-5">
-        {reset && (
-          <button type="button" onClick={reset} className="t-small font-medium text-link underline underline-offset-4">
-            {s.tryAgain}
-          </button>
-        )}
-        <Link href="/" className="t-small font-medium text-link underline underline-offset-4">{s.backHome}</Link>
-      </div>
-    </div>
+    <ErrorScreen code={code} title={s.errorTitle} text={s.errorText}>
+      {reset && (
+        <button type="button" onClick={reset} className={ERROR_LINK}>{s.tryAgain}</button>
+      )}
+      <Link href="/" className={ERROR_LINK}>{s.backHome}</Link>
+    </ErrorScreen>
   )
 }


### PR DESCRIPTION
All error/edge screens now route through one `ErrorScreen` component: public 404, 5xx boundaries (`ErrorView`), and a new admin 404 (`app/admin/not-found.tsx`). Identical layout everywhere, shared `ERROR_LINK`. Public 404 keeps the blog shell; admin 404 uses the admin shell. Other 4xx (401/403) stay auth redirects/JSON by design.

Verified: tsc / lint / build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)