### PR TITLE
Hardening: edge owner-guard, Google-only login, MCP 180-day token expiry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,8 @@ next-env.d.ts
 # Local media-wipe backup artifacts
 media-index-backup-*.json
 
+# Local blob-cleanup backups (contain real site content — never commit)
+audit/legacy-blob-backup-*/
+
 # Local env backups
 .env.local.bak*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CHANGELOG
 
+## 2026-06-22 (v1.0.10 — hardening: edge guard, Google-only, MCP token expiry)
+- **feat(security): `src/middleware.ts` edge owner-guard (defense-in-depth).** Reads the NextAuth
+  JWT and blocks `/admin/:path*` (→ sign-in) and owner-only `/api/:path*` (→ 401) BEFORE the route
+  runs — so a new admin page or API route is protected even if it forgets `requireOwner()`. Self-
+  authed/public paths are allow-listed (`/api/auth`, `/api/cron`, `/api/track`, `/api/search`,
+  `/api/mcp` except `/api/mcp/tokens`); add new public/bearer routes to `isPublicApi()`.
+- **change(auth): Google is now the ONLY sign-in provider.** Dropped the GitHub OAuth provider
+  (`auth.ts`, `.env.example`, README). `AUTH_GITHUB_ID/SECRET` are no longer read.
+- **feat(security): MCP tokens now expire 180 days after creation.** New `mcp_tokens.expires_at`
+  column (migration `mcp_tokens_add_expires_at`; default in `schema.sql`); `createToken` /
+  `mintOAuthToken` set it on insert; `verifyTokenHash` rejects an expired bearer. The admin token
+  table shows an **Expires** column (red "Expired" when past). Connectors silently re-authorize
+  across the boundary; a manual token must be recreated. New locale keys `mcpColExpires` / `mcpExpired`
+  in all 6 languages. The admin remains the sole authority over deletion. `v1.0.10`.
+
 ## 2026-06-22 (v1.0.9 — every error page shares one look)
 - **refactor: all error/edge screens now route through ONE `ErrorScreen` component** so they can't
   drift. The public 404, the 5xx boundaries (`ErrorView`), and a new **admin 404**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,17 +183,20 @@ are called out elsewhere (Caching, Typography, Conventions).
   `settings.mcp.enabled`); `verifyMcpToken` 401s every call while off.
 - **Auth = admin-managed tokens + thin OAuth.** Manual tokens are created in the admin (up to 5,
   named, shown ONCE on creation — only the SHA-256 hash is kept in the `mcp_tokens` table; see
-  `lib/mcp/tokens.ts`). All tokens are **eternal (no expiry)**. `verifyMcpToken` hashes the bearer +
-  looks it up (and stamps `last_used_at`) while the toggle is on. There is **no `MCP_TOKEN` env var.**
-  Connectors that require OAuth run a minimal OAuth 2.1 authorization-code + PKCE flow gated by the
-  owner's NextAuth login (`src/app/api/mcp/{authorize,token,register}` + `src/app/.well-known/oauth-*`);
-  the `/token` exchange **mints an eternal token via `mintOAuthToken`** (named "OAuth connector") and
-  returns it. **OAuth tokens are exempt from the manual 5-cap and are NEVER auto-deleted.**
-  **Lifecycle rule: the admin is the SOLE authority over a connection** — a token persists forever
-  (no expiry, no prune) until the OWNER deletes it in the admin; deleting the connector in Claude
-  alone just lets it re-authorize (a new token). So authorize once = stays connected indefinitely,
-  and an admin delete is final unless the owner re-authorizes. (A reconnect mints a new row; the
-  prior one persists until the owner removes it — the admin lists/deletes them all.) Codes are HMAC-signed
+  `lib/mcp/tokens.ts`). Every token **expires 180 days after creation** (`expires_at`, set on insert,
+  default in `schema.sql`); `verifyMcpToken` hashes the bearer, looks it up, **rejects it once past
+  `expires_at`**, else stamps `last_used_at` (while the toggle is on). There is **no `MCP_TOKEN` env
+  var.** Connectors that require OAuth run a minimal OAuth 2.1 authorization-code + PKCE flow gated by
+  the owner's NextAuth login (`src/app/api/mcp/{authorize,token,register}` + `src/app/.well-known/oauth-*`);
+  the `/token` exchange **mints a 180-day token via `mintOAuthToken`** (named "OAuth connector") and
+  returns it. **OAuth tokens are exempt from the manual 5-cap and are NEVER auto-deleted** (an expired
+  row lingers as dead until the owner deletes it; a connector silently re-authorizes to mint a fresh one).
+  **Lifecycle rule: the admin is the SOLE authority over a connection** — beyond the 180-day expiry a
+  token persists (no prune) until the OWNER deletes it in the admin; deleting the connector in Claude
+  alone just lets it re-authorize (a new token). So authorize once = stays connected (connector
+  re-auths across the 180-day boundary), and an admin delete is final unless the owner re-authorizes.
+  (A reconnect mints a new row; the prior one persists until the owner removes it — the admin
+  lists/deletes them all.) Codes are HMAC-signed
   (`MCP_OAUTH_SECRET` → falls back to `AUTH_SECRET`) in `lib/mcp/auth.ts`. Token CRUD: owner-only
   `/api/mcp/tokens` (+ `/[id]`); UI in `components/admin/McpFields.tsx` (cap counts manual only).
 - **Tools** (`lib/mcp/tools.ts` posts/pages/taxonomy, `tools-library.ts` media/files/settings;
@@ -408,7 +411,13 @@ are called out elsewhere (Caching, Typography, Conventions).
   (components only).
 - Max 400 lines per file. No `any` (use `unknown` + narrowing).
 - Every API handler: time + log the request, try/catch with logged errors. Auth: only
-  `AUTHORIZED_EMAIL` reaches `/admin`; all write/delete routes are owner-gated server-side (401).
+  `AUTHORIZED_EMAIL` reaches `/admin`; all write/delete routes are owner-gated server-side (401)
+  via `requireOwner()`. **`src/middleware.ts` is the edge defense-in-depth net** — it reads the
+  NextAuth JWT and blocks `/admin/:path*` (→ sign-in) and owner-only `/api/:path*` (→ 401) even if a
+  new route forgets `requireOwner()`. It **allow-lists self-authed/public paths** (`/api/auth`,
+  `/api/cron`, `/api/track`, `/api/search`, `/api/mcp` except `/api/mcp/tokens`) — a NEW public or
+  bearer/secret-authed API route must be added to `isPublicApi()` there or it gets 401'd. Google is
+  the ONLY sign-in provider.
 
 ## Next.js 16
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vibe**blog** (v1.0.9)
+# vibe**blog** (v1.0.10)
 
 An AI-operated personal blog platform. Write and publish from a multilingual admin
 UI. Text content (posts, pages, settings, metadata) lives in **Supabase Postgres**;
@@ -6,14 +6,14 @@ binaries (images, attachments, icons) live in **Vercel Blob**.
 
 - **Framework:** Next.js 16 (App Router) + React 19 + TypeScript (strict)
 - **Storage:** Supabase Postgres for all text (`posts`/`pages`/`post_revisions`/`media`/`files`/`settings` tables; post bodies are Markdown in a text column); Vercel Blob for binaries only. Image refs stored store-relative (no vendor lock-in)
-- **Auth:** NextAuth v5 (Google and/or GitHub OAuth), single authorized owner
+- **Auth:** NextAuth v5 (Google OAuth), single authorized owner
 - **Editor:** TipTap 3 with Markdown; responsive images via `sharp` (original + AVIF/WebP variants, encoded in the background after save); a 3-version time machine per post
 - **Theming:** 6 built-in light+dark color palettes, each fully customizable; visitors can switch palette and light/dark/system/by-time mode; optional custom CSS
 - **Typography:** one tunable type system — every text role (h1–h5, body, small, caption, code) has its own size / line-height / letter-spacing, applied site-wide via CSS variables (no hardcoded sizes); upload a custom typeface per weight (Regular/Medium/SemiBold/Bold); one font for everything
 - **PWA:** installable to the iPhone/Android home screen, launches standalone (no service worker / no offline by design)
 - **Admin:** Overview with a System panel (hosting/region/env + database + storage); a toggleable activity log (Admin → Log) recording every save/upload/delete
 - **Trash:** every delete (posts, pages, media, files) is a recoverable soft delete; an Admin → Trash area restores or permanently removes items per type — nothing auto-purges
-- **MCP server (optional):** a remote MCP endpoint (`/api/mcp`) lets an AI agent (Claude, ChatGPT) write and manage the blog with the same data layer as the admin UI. Toggle it on in Admin → Settings → Advanced and generate up to 5 named access tokens there (shown once, hashed at rest, revocable); a thin OAuth layer covers connectors that need it; sensitive settings are blocked
+- **MCP server (optional):** a remote MCP endpoint (`/api/mcp`) lets an AI agent (Claude, ChatGPT) write and manage the blog with the same data layer as the admin UI. Toggle it on in Admin → Settings → Advanced and generate up to 5 named access tokens there (shown once, hashed at rest, revocable, expire after 180 days); a thin OAuth layer covers connectors that need it; sensitive settings are blocked
 - **UI languages:** en (default), vi, de, ja, zh, ko
 - **Styles:** Tailwind CSS v4
 - **Deploy:** Vercel (Docker self-host is on the [roadmap](./ROADMAP.md))
@@ -27,7 +27,7 @@ binaries (images, attachments, icons) live in **Vercel Blob**.
 - A **Supabase** project (free tier is fine) — holds all text content.
 - A **Vercel Blob** store — holds binaries (images/files/icons). You need its
   read/write token; you don't have to deploy to Vercel to use Blob locally.
-- At least one **OAuth app** — Google and/or GitHub — for admin sign-in.
+- A **Google OAuth app** — for admin sign-in.
 
 ### Steps
 
@@ -51,12 +51,10 @@ binaries (images, attachments, icons) live in **Vercel Blob**.
    the store's **`.env` / Tokens** tab copy the `BLOB_READ_WRITE_TOKEN`
    (`vercel_blob_rw_…`). No need to deploy first.
 
-5. **Create an OAuth app** (at least one):
-   - **Google** — [Cloud Console](https://console.cloud.google.com/) → Credentials →
+5. **Create a Google OAuth app.**
+   - [Cloud Console](https://console.cloud.google.com/) → Credentials →
      OAuth client ID (Web). Authorized redirect URI:
      `http://localhost:3000/api/auth/callback/google`.
-   - **GitHub** — Settings → Developer settings → OAuth Apps → New. Callback URL:
-     `http://localhost:3000/api/auth/callback/github`.
 
 6. **Configure env.**
 
@@ -82,8 +80,7 @@ See [`.env.example`](./.env.example). In short:
 | --------------------------------- | ----------------------------------------- |
 | `AUTH_SECRET`                     | NextAuth secret — `npx auth secret`       |
 | `AUTHORIZED_EMAIL`                | The only email allowed into `/admin`      |
-| `AUTH_GOOGLE_ID` / `_SECRET`      | Google OAuth client (optional provider)   |
-| `AUTH_GITHUB_ID` / `_SECRET`      | GitHub OAuth app (optional provider)      |
+| `AUTH_GOOGLE_ID` / `_SECRET`      | Google OAuth client                       |
 | `SUPABASE_URL`                    | Supabase project API URL                  |
 | `SUPABASE_SERVICE_ROLE_KEY`       | Supabase service_role key (secret, server-only) |
 | `BLOB_READ_WRITE_TOKEN`           | Vercel Blob read/write token              |
@@ -144,12 +141,10 @@ the dashboard, or hand the whole job to an AI agent.
    - `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` — from step 2.
    - `AUTH_SECRET` — run `npx auth secret` and paste the output.
    - `AUTHORIZED_EMAIL` — the single email allowed into `/admin`.
-   - At least one OAuth provider: `AUTH_GOOGLE_ID` + `AUTH_GOOGLE_SECRET`, and/or
-     `AUTH_GITHUB_ID` + `AUTH_GITHUB_SECRET`.
+   - Google OAuth: `AUTH_GOOGLE_ID` + `AUTH_GOOGLE_SECRET`.
 6. **Deploy.**
-7. **Register the OAuth callback URL** with your provider, using the live domain:
-   - Google: `https://<your-domain>/api/auth/callback/google`
-   - GitHub: `https://<your-domain>/api/auth/callback/github`
+7. **Register the OAuth callback URL** with Google, using the live domain:
+   - `https://<your-domain>/api/auth/callback/google`
 
    Add both your `*.vercel.app` URL and any custom domain.
 8. Open `https://<your-domain>/admin`, sign in as `AUTHORIZED_EMAIL`, and set your
@@ -178,7 +173,7 @@ on it, create a Vercel project from the fork, add a Blob store, generate `AUTH_S
 set the environment variables above (incl. `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`),
 deploy, and return the live URL.* Finish by registering the OAuth callback URL (step 7
 above) and signing in at `/admin`. The only step an agent can't do alone is the OAuth
-**provider** setup (it needs your Google/GitHub login) — pre-create that app, or grant access.
+**provider** setup (it needs your Google login) — pre-create that app, or grant access.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeblog",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "license": "MIT",
   "browserslist": [

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -106,9 +106,16 @@ create table if not exists public.mcp_tokens (
   token_hash   text not null unique,
   prefix       text not null default '',
   created_at   timestamptz not null default now(),
+  -- Tokens expire 180 days after creation; the app sets this explicitly on insert
+  -- and rejects an expired bearer. (Connectors silently re-authorize; a manual
+  -- token must be recreated.)
+  expires_at   timestamptz not null default (now() + interval '180 days'),
   last_used_at timestamptz
 );
 create index if not exists mcp_tokens_hash_idx on public.mcp_tokens (token_hash);
+-- Upgrade path: add expires_at to a pre-existing mcp_tokens table (no-op on fresh installs).
+alter table public.mcp_tokens
+  add column if not exists expires_at timestamptz not null default (now() + interval '180 days');
 
 -- ----- activity_log ----------------------------------------------------------
 create table if not exists public.activity_log (

--- a/src/components/admin/McpFields.tsx
+++ b/src/components/admin/McpFields.tsx
@@ -167,6 +167,7 @@ export function McpFields({ mcp, onChange }: { mcp: McpSettings; onChange: (m: M
                   <th className="px-3 py-2 font-medium">{t.mcpColName}</th>
                   <th className="hidden px-3 py-2 font-medium sm:table-cell">{t.mcpColCreated}</th>
                   <th className="hidden px-3 py-2 font-medium sm:table-cell">{t.mcpColLastUsed}</th>
+                  <th className="hidden px-3 py-2 font-medium sm:table-cell">{t.mcpColExpires}</th>
                   <th className="px-3 py-2" />
                 </tr>
               </thead>
@@ -182,6 +183,13 @@ export function McpFields({ mcp, onChange }: { mcp: McpSettings; onChange: (m: M
                     </td>
                     <td className="hidden whitespace-nowrap px-3 py-2 text-neutral-500 sm:table-cell dark:text-neutral-400">
                       {tok.lastUsedAt ? formatDateTimeShort(tok.lastUsedAt) : t.mcpNeverUsed}
+                    </td>
+                    <td className="hidden whitespace-nowrap px-3 py-2 sm:table-cell">
+                      {tok.expired ? (
+                        <span className="text-red-600 dark:text-red-400">{t.mcpExpired}</span>
+                      ) : (
+                        <span className="text-neutral-500 dark:text-neutral-400">{formatDateTimeShort(tok.expiresAt)}</span>
+                      )}
                     </td>
                     <td className="px-3 py-2 text-right">
                       <button

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,13 +1,11 @@
-// NextAuth v5 config: OAuth sign-in, single authorized owner.
-// Providers (Google, GitHub) are enabled per env — only the ones whose
-// credentials are present load, so a self-hoster can pick either or both.
+// NextAuth v5 config: Google OAuth sign-in, single authorized owner.
+// Google is the only provider; it loads when its credentials are present.
 // Anyone can sign in, but only AUTHORIZED_EMAIL is treated as authorized.
 // Unauthorized accounts are not blocked at sign-in (no error page); access is
 // gated downstream so they are silently redirected to the homepage.
 
 import NextAuth from 'next-auth'
 import type { Provider } from 'next-auth/providers'
-import GitHub from 'next-auth/providers/github'
 import Google from 'next-auth/providers/google'
 
 // Normalize for comparison: email is case-insensitive in practice and providers
@@ -15,10 +13,9 @@ import Google from 'next-auth/providers/google'
 const normalizeEmail = (e?: string | null): string => (e ?? '').trim().toLowerCase()
 const AUTHORIZED_EMAIL = normalizeEmail(process.env.AUTHORIZED_EMAIL)
 
-// Load only the providers that have credentials configured.
+// Google loads only when its credentials are configured.
 const providers: Provider[] = []
 if (process.env.AUTH_GOOGLE_ID) providers.push(Google)
-if (process.env.AUTH_GITHUB_ID) providers.push(GitHub)
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   providers,

--- a/src/lib/mcp/tokens.ts
+++ b/src/lib/mcp/tokens.ts
@@ -8,6 +8,10 @@ import { db } from '@/lib/db'
 
 const MAX_TOKENS = 5 // manual (admin-created) tokens only
 const TOKEN_PREFIX = 'vbmcp_'
+const TOKEN_TTL_DAYS = 180 // every token expires this long after creation
+
+// Expiry stamp for a freshly minted token (created_at + TTL).
+const expiryISO = (): string => new Date(Date.now() + TOKEN_TTL_DAYS * 86_400_000).toISOString()
 
 // OAuth-issued tokens share this name and are managed separately from manual ones:
 // exempt from MAX_TOKENS. They are NEVER auto-deleted — a connection persists until
@@ -21,11 +25,13 @@ export type McpTokenInfo = {
   name: string
   prefix: string // short non-secret display hint, e.g. "vbmcp_AbCd"
   createdAt: string
+  expiresAt: string // created_at + 180d; rejected once past
+  expired: boolean // computed server-side (past expiresAt) for display
   lastUsedAt: string | null
   oauth: boolean // true = machine-issued via OAuth (not a manual admin token)
 }
 
-type TokenRow = { id: number; name: string; prefix: string; created_at: string; last_used_at: string | null }
+type TokenRow = { id: number; name: string; prefix: string; created_at: string; expires_at: string; last_used_at: string | null }
 
 const sha256 = (s: string): string => createHash('sha256').update(s).digest('hex')
 
@@ -34,6 +40,8 @@ const toInfo = (r: TokenRow): McpTokenInfo => ({
   name: r.name,
   prefix: r.prefix,
   createdAt: r.created_at,
+  expiresAt: r.expires_at,
+  expired: Date.parse(r.expires_at) <= Date.now(),
   lastUsedAt: r.last_used_at,
   oauth: r.name === OAUTH_TOKEN_NAME,
 })
@@ -44,7 +52,7 @@ export const tokenLimit = (): number => MAX_TOKENS
 export async function listTokens(): Promise<McpTokenInfo[]> {
   const { data } = await db()
     .from('mcp_tokens')
-    .select('id,name,prefix,created_at,last_used_at')
+    .select('id,name,prefix,created_at,expires_at,last_used_at')
     .order('created_at', { ascending: false })
   return ((data as TokenRow[] | null) ?? []).map(toInfo)
 }
@@ -67,8 +75,8 @@ export async function createToken(name: string): Promise<{ token: string; info: 
   const { token, prefix } = newSecret()
   const { data, error } = await db()
     .from('mcp_tokens')
-    .insert({ name: name.trim().slice(0, 80) || 'Token', token_hash: sha256(token), prefix })
-    .select('id,name,prefix,created_at,last_used_at')
+    .insert({ name: name.trim().slice(0, 80) || 'Token', token_hash: sha256(token), prefix, expires_at: expiryISO() })
+    .select('id,name,prefix,created_at,expires_at,last_used_at')
     .single()
   if (error) throw new Error(`createToken: ${error.message}`)
   return { token, info: toInfo(data as TokenRow) }
@@ -82,8 +90,8 @@ export async function mintOAuthToken(): Promise<{ token: string; info: McpTokenI
   const { token, prefix } = newSecret()
   const { data, error } = await db()
     .from('mcp_tokens')
-    .insert({ name: OAUTH_TOKEN_NAME, token_hash: sha256(token), prefix })
-    .select('id,name,prefix,created_at,last_used_at')
+    .insert({ name: OAUTH_TOKEN_NAME, token_hash: sha256(token), prefix, expires_at: expiryISO() })
+    .select('id,name,prefix,created_at,expires_at,last_used_at')
     .single()
   if (error) throw new Error(`mintOAuthToken: ${error.message}`)
   return { token, info: toInfo(data as TokenRow) }
@@ -93,12 +101,14 @@ export async function deleteToken(id: number): Promise<void> {
   await db().from('mcp_tokens').delete().eq('id', id)
 }
 
-// Verify a presented bearer: hash + lookup. On a match, stamp last_used_at and
-// return the token's id/name; otherwise null.
+// Verify a presented bearer: hash + lookup. Rejects an expired token (past
+// expires_at). On a live match, stamps last_used_at and returns the token's
+// id/name; otherwise null.
 export async function verifyTokenHash(bearer: string): Promise<{ id: number; name: string } | null> {
-  const { data } = await db().from('mcp_tokens').select('id,name').eq('token_hash', sha256(bearer)).maybeSingle()
+  const { data } = await db().from('mcp_tokens').select('id,name,expires_at').eq('token_hash', sha256(bearer)).maybeSingle()
   if (!data) return null
-  const r = data as { id: number; name: string }
+  const r = data as { id: number; name: string; expires_at: string }
+  if (Date.parse(r.expires_at) <= Date.now()) return null // expired → treat as invalid
   await db().from('mcp_tokens').update({ last_used_at: new Date().toISOString() }).eq('id', r.id)
-  return r
+  return { id: r.id, name: r.name }
 }

--- a/src/locales/admin/de.ts
+++ b/src/locales/admin/de.ts
@@ -310,6 +310,8 @@ const de = {
   mcpColName: 'Name',
   mcpColCreated: 'Erstellt',
   mcpColLastUsed: 'Zuletzt benutzt',
+  mcpColExpires: 'Läuft ab',
+  mcpExpired: 'Abgelaufen',
   mcpRefresh: 'Aktualisieren',
   mcpNeverUsed: 'Nie',
   mcpConfirmDelete: 'Diesen Token löschen? Jeder Client, der ihn nutzt, funktioniert nicht mehr.',

--- a/src/locales/admin/en.ts
+++ b/src/locales/admin/en.ts
@@ -310,6 +310,8 @@ const en = {
   mcpColName: 'Name',
   mcpColCreated: 'Created',
   mcpColLastUsed: 'Last used',
+  mcpColExpires: 'Expires',
+  mcpExpired: 'Expired',
   mcpRefresh: 'Refresh',
   mcpNeverUsed: 'Never',
   mcpConfirmDelete: 'Delete this token? Any client using it will stop working.',

--- a/src/locales/admin/ja.ts
+++ b/src/locales/admin/ja.ts
@@ -310,6 +310,8 @@ const ja = {
   mcpColName: '名前',
   mcpColCreated: '作成日',
   mcpColLastUsed: '最終使用',
+  mcpColExpires: '有効期限',
+  mcpExpired: '期限切れ',
   mcpRefresh: '更新',
   mcpNeverUsed: '未使用',
   mcpConfirmDelete: 'このトークンを削除しますか？使用中のクライアントは動作しなくなります。',

--- a/src/locales/admin/ko.ts
+++ b/src/locales/admin/ko.ts
@@ -310,6 +310,8 @@ const ko = {
   mcpColName: '이름',
   mcpColCreated: '생성일',
   mcpColLastUsed: '마지막 사용',
+  mcpColExpires: '만료',
+  mcpExpired: '만료됨',
   mcpRefresh: '새로고침',
   mcpNeverUsed: '사용 안 함',
   mcpConfirmDelete: '이 토큰을 삭제할까요? 이를 사용하는 모든 클라이언트가 작동을 멈춥니다.',

--- a/src/locales/admin/vi.ts
+++ b/src/locales/admin/vi.ts
@@ -310,6 +310,8 @@ const vi = {
   mcpColName: 'Tên',
   mcpColCreated: 'Tạo lúc',
   mcpColLastUsed: 'Dùng gần nhất',
+  mcpColExpires: 'Hết hạn',
+  mcpExpired: 'Đã hết hạn',
   mcpRefresh: 'Làm mới',
   mcpNeverUsed: 'Chưa dùng',
   mcpConfirmDelete: 'Xoá token này? Mọi client đang dùng nó sẽ ngừng hoạt động.',

--- a/src/locales/admin/zh.ts
+++ b/src/locales/admin/zh.ts
@@ -310,6 +310,8 @@ const zh = {
   mcpColName: '名称',
   mcpColCreated: '创建时间',
   mcpColLastUsed: '最近使用',
+  mcpColExpires: '过期时间',
+  mcpExpired: '已过期',
   mcpRefresh: '刷新',
   mcpNeverUsed: '从未使用',
   mcpConfirmDelete: '删除此令牌？正在使用它的客户端将停止工作。',

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -367,6 +367,8 @@ export type AdminStrings = {
   mcpColName: string
   mcpColCreated: string
   mcpColLastUsed: string
+  mcpColExpires: string
+  mcpExpired: string
   mcpRefresh: string
   mcpNeverUsed: string
   mcpConfirmDelete: string

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,42 @@
+// Edge owner-guard — defense-in-depth on top of each route's `requireOwner()`.
+// Reads the NextAuth JWT (no DB) and lets only the configured owner past. A new
+// admin page or owner-only API route is protected even if it forgets the in-route
+// check. Public / self-authed endpoints are allow-listed so they keep working
+// without an owner session (analytics beacon, search, cron, the MCP transport).
+
+import { NextResponse } from 'next/server'
+import { auth, isAuthorized } from '@/lib/auth'
+
+// Paths that handle their own auth (bearer token, CRON_SECRET, PKCE) or are public
+// reads, so they must NOT require an owner session. Note: /api/mcp covers the MCP
+// transport + OAuth flow, but /api/mcp/tokens is owner-only admin CRUD.
+function isPublicApi(pathname: string): boolean {
+  if (pathname.startsWith('/api/mcp/tokens')) return false
+  return (
+    pathname.startsWith('/api/auth') ||
+    pathname.startsWith('/api/cron') ||
+    pathname.startsWith('/api/track') ||
+    pathname.startsWith('/api/search') ||
+    pathname.startsWith('/api/mcp')
+  )
+}
+
+export default auth((req) => {
+  const { pathname } = req.nextUrl
+  if (isAuthorized(req.auth?.user?.email)) return // owner → proceed
+
+  // Admin UI → bounce to sign-in (mirrors the /admin layout guard).
+  if (pathname.startsWith('/admin')) {
+    const url = new URL('/api/auth/signin', req.nextUrl.origin)
+    url.searchParams.set('callbackUrl', pathname)
+    return NextResponse.redirect(url)
+  }
+  // Owner-only API → 401, unless it authenticates itself (allow-listed above).
+  if (pathname.startsWith('/api') && !isPublicApi(pathname)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+})
+
+export const config = {
+  matcher: ['/admin/:path*', '/api/:path*'],
+}


### PR DESCRIPTION
## Hardening (phase 1 of the agreed security work)

### 1. `src/middleware.ts` — edge owner-guard (defense-in-depth)
Reads the NextAuth JWT and blocks `/admin/:path*` (→ sign-in) and owner-only `/api/:path*` (→ 401) **before** the route runs, so a new admin page or API route is protected even if it forgets `requireOwner()`. Self-authed/public paths are allow-listed in `isPublicApi()`: `/api/auth`, `/api/cron`, `/api/track`, `/api/search`, `/api/mcp` (except `/api/mcp/tokens`).

### 2. Google-only login
Dropped the GitHub OAuth provider (`auth.ts`, `.env.example`, README). `AUTH_GITHUB_*` no longer read.

### 3. MCP tokens expire after 180 days
- New `mcp_tokens.expires_at` column — `schema.sql` (with idempotent upgrade `ALTER`) + live migration `mcp_tokens_add_expires_at` (already applied to prod).
- `createToken` / `mintOAuthToken` set it on insert; `verifyTokenHash` rejects expired bearers.
- Admin token table shows an **Expires** column (red "Expired" when past). New locale keys `mcpColExpires` / `mcpExpired` in all 6 languages.
- Connectors silently re-authorize across the boundary; the admin stays the sole authority over deletion.

## Verify
`npm run build`, `npm run lint`, `npm run typecheck` all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)