### PR TITLE
Fix Drive connect redirect_uri_mismatch + tidy Backups layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 2026-06-22 (v1.0.13 — fix Drive connect redirect + tidy Backups layout)
+- **fix(backup): `redirect_uri_mismatch` connecting Google Drive.** The consent + token-exchange
+  redirect URI was built from `req.nextUrl.origin`, which is a `*.vercel.app` host when the admin
+  is reached there (sign-in still works because NextAuth uses `AUTH_URL`) — so it didn't match the
+  one URI registered on the OAuth client. New `backupRedirectUri(settings)` derives it from the
+  canonical `resolveSiteUrl(settings)` (e.g. `https://manhhung.me/api/backup/callback`), used by
+  both `/api/backup/connect` and `/api/backup/callback`. Register that exact URI on the client.
+- **ui(backup): the Backups card no longer spans full width.** It now sits in the same two-column
+  Advanced grid as MCP + custom CSS, so the section reads evenly. `v1.0.13`.
+
 ## 2026-06-22 (v1.0.12 — slugified taxonomy URLs + clearer Overview)
 - **fix(seo): category/tag URLs now use the slugified term**, e.g. `/category/suy-nghi` instead of
   `/category/Suy%20ngh%C4%A9`. New `lib/taxonomy.ts` (`termSlug`/`resolveTerm`); post-footer links +

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,7 +226,11 @@ are called out elsewhere (Caching, Typography, Conventions).
 - **Auth is SEPARATE from sign-in.** A dedicated `drive.file` OAuth flow (reuses the Google
   client `AUTH_GOOGLE_*`, never touches the login scope): `GET /api/backup/connect` → Google
   consent → `GET /api/backup/callback` exchanges the code for a **refresh token**, stored in
-  `backup_state` (server-only). `drive.file` = the app only ever sees files IT created.
+  `backup_state` (server-only). `drive.file` = the app only ever sees files IT created. The
+  **redirect URI is `backupRedirectUri(settings)` = `${resolveSiteUrl(settings)}/api/backup/callback`**
+  — derived from the canonical site URL, NOT `req.nextUrl.origin` (which is a `*.vercel.app` host
+  when the admin is opened there → `redirect_uri_mismatch`). So the URI registered on the OAuth
+  client must use the canonical host (`settings.siteUrl`).
 - **Secret hygiene (HARD RULE).** The Drive refresh token must NEVER reach the client. It lives
   in `backup_state`, NOT in `settings.data` (which is sent to the admin). Only non-secret config
   (`enabled`/`intervalDays`/`keep`) lives in `settings.backups` and flows through the settings

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vibe**blog** (v1.0.12)
+# vibe**blog** (v1.0.13)
 
 An AI-operated personal blog platform. Write and publish from a multilingual admin
 UI. Text content (posts, pages, settings, metadata) lives in **Supabase Postgres**;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeblog",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "private": true,
   "license": "MIT",
   "browserslist": [

--- a/src/app/api/backup/callback/route.ts
+++ b/src/app/api/backup/callback/route.ts
@@ -3,7 +3,8 @@
 // bounces back to Settings → Advanced. Owner-only (middleware + requireOwner).
 
 import type { NextRequest } from 'next/server'
-import { exchangeCode, verifyState } from '@/lib/gdrive'
+import { exchangeCode, verifyState, backupRedirectUri } from '@/lib/gdrive'
+import { getSettings } from '@/lib/settings'
 import { setDriveAuth } from '@/lib/backup-state'
 import { logActivity } from '@/lib/activity'
 import { logRequest, logError, requireOwner } from '@/lib/api'
@@ -30,7 +31,8 @@ export async function GET(req: NextRequest): Promise<Response> {
       logRequest(req, 400, start)
       return back(origin, 'error')
     }
-    const refreshToken = await exchangeCode(code, `${origin}/api/backup/callback`)
+    // Must match the redirect_uri used in the consent step (canonical, not origin).
+    const refreshToken = await exchangeCode(code, backupRedirectUri(await getSettings()))
     await setDriveAuth(refreshToken)
     await logActivity('backup.connect', 'Google Drive')
     logRequest(req, 302, start)

--- a/src/app/api/backup/connect/route.ts
+++ b/src/app/api/backup/connect/route.ts
@@ -3,7 +3,8 @@
 // a refresh token without touching the login scope. The callback stores the token.
 
 import type { NextRequest } from 'next/server'
-import { consentUrl, signState } from '@/lib/gdrive'
+import { consentUrl, signState, backupRedirectUri } from '@/lib/gdrive'
+import { getSettings } from '@/lib/settings'
 import { fail, logRequest, logError, requireOwner } from '@/lib/api'
 
 export const dynamic = 'force-dynamic'
@@ -15,7 +16,10 @@ export async function GET(req: NextRequest): Promise<Response> {
       logRequest(req, 401, start)
       return fail('Unauthorized', 401)
     }
-    const redirectUri = `${req.nextUrl.origin}/api/backup/callback`
+    // Deterministic redirect from the canonical site URL (NOT the request origin),
+    // so it always matches the one URI registered on the OAuth client even when the
+    // admin is reached via a *.vercel.app host.
+    const redirectUri = backupRedirectUri(await getSettings())
     const url = consentUrl(redirectUri, signState())
     logRequest(req, 302, start)
     return Response.redirect(url, 302)

--- a/src/components/admin/SettingsView.tsx
+++ b/src/components/admin/SettingsView.tsx
@@ -153,11 +153,10 @@ export function SettingsView({ settings, presets }: { settings: SiteSettings; pr
       )}
 
       {tab === 'advanced' && (
-        <div className="space-y-6">
+        <div className="grid items-start gap-6 lg:grid-cols-2">
           <Card title={t.backupTitle}>
             <BackupFields backups={s.backups} onChange={(backups) => update({ backups })} />
           </Card>
-          <div className="grid items-start gap-6 lg:grid-cols-2">
           <Card title={t.cardMcp}>
             <McpFields mcp={s.mcp} onChange={(mcp) => update({ mcp })} />
           </Card>
@@ -174,7 +173,6 @@ export function SettingsView({ settings, presets }: { settings: SiteSettings; pr
               <p className="text-xs text-neutral-400 dark:text-neutral-500">{t.customCssHint}</p>
             </div>
           </Card>
-          </div>
         </div>
       )}
 

--- a/src/lib/gdrive.ts
+++ b/src/lib/gdrive.ts
@@ -4,8 +4,17 @@
 // limits access to files this app creates — it can never see the rest of the Drive.
 
 import { createHmac, timingSafeEqual } from 'node:crypto'
+import type { SiteSettings } from '@/types'
+import { resolveSiteUrl } from '@/lib/settings'
 
 const SCOPE = 'https://www.googleapis.com/auth/drive.file'
+
+// The OAuth redirect URI, derived from the canonical site URL so it is stable and
+// matches the single URI registered on the Google client — independent of which host
+// (custom domain vs *.vercel.app) the admin is being reached from.
+export function backupRedirectUri(settings: SiteSettings): string {
+  return `${resolveSiteUrl(settings)}/api/backup/callback`
+}
 const AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth'
 const TOKEN_URL = 'https://oauth2.googleapis.com/token'
 const FOLDER_NAME = 'vibeblog-backups'


### PR DESCRIPTION
## 1. Fix `redirect_uri_mismatch` connecting Google Drive
The consent + token-exchange redirect URI was built from `req.nextUrl.origin`. When the admin is opened on a `*.vercel.app` host, that origin is the vercel.app domain (sign-in still works because NextAuth uses `AUTH_URL`), so the redirect URI didn't match the one registered on the OAuth client → `redirect_uri_mismatch`.

New `backupRedirectUri(settings)` = `${resolveSiteUrl(settings)}/api/backup/callback` — derived from the **canonical** site URL (`settings.siteUrl`, e.g. `https://manhhung.me`), used by both `/api/backup/connect` and `/api/backup/callback`. Stable regardless of access host.

## 2. Tidy Backups layout
The Backups card no longer spans full width — it sits in the same two-column Advanced grid as MCP + custom CSS.

## Verify
`npm run build`, `npm run lint`, `npm run typecheck` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)