### PR TITLE
docs: rewrite README (2 install paths + MCP publish, polished)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -476,6 +476,11 @@ On any behavior change, update the matching doc in the SAME change (Working prin
 - **CLAUDE.md** (this) = rules / data-layer / caching / gotchas. **ARCHITECTURE.md** = overview
   + why. **CHANGELOG.md** = one entry per user-facing change. **CHECKLIST.md** = pre-deploy
   steps. **README.md** = setup + features. **ROADMAP.md** = direction.
+- **README is the canonical install/usage doc — keep it current.** Its **two install paths**
+  (1️⃣ do-it-yourself, 2️⃣ hand-to-an-AI-agent) + the **MCP "let an agent write & publish"** section
+  + the **env-var table** must be updated in the SAME change whenever setup/deploy/env/auth/MCP/backup
+  behavior changes (new/renamed env var, a new owner setup step, a changed redirect URI, etc.).
+  Never let the README drift from how the app is actually installed and run.
 - Keep personal/instance values (credentials, Vercel/Blob IDs, the live domain) OUT of tracked
   files — `.env.local` + Vercel only.
 - **Audits** (`audit/`): a full review per `audit/README.md` → dated `audit/YYYY-MM-DD-<scope>.md`;
@@ -484,6 +489,6 @@ On any behavior change, update the matching doc in the SAME change (Working prin
   owner cut **1.0.0** with the MCP + Trash release). Each change bumps the patch `x`
   (→ `1.0.999`), a running counter with no semver meaning. NEVER raise `1.0` → `1.1` or `→ 2.0`
   unless the owner asks. A code change bumps `x`; pure-docs may skip. On a bump, also update the
-  **README H1** `# vibeblog (v1.0.x)`.
+  **README version badge** (`![Version](https://img.shields.io/badge/version-1.0.x-…)`).
 - **Cutting a release:** `x` already current; `npm run build` + `npm run lint` exit 0; push `main`;
   `gh release create v1.0.<x> --title "v1.0.<x> - <tagline>" --notes "…"`.

--- a/README.md
+++ b/README.md
@@ -1,226 +1,168 @@
-# vibe**blog** (v1.0.13)
+<div align="center">
 
-An AI-operated personal blog platform. Write and publish from a multilingual admin
-UI. Text content (posts, pages, settings, metadata) lives in **Supabase Postgres**;
-binaries (images, attachments, icons) live in **Vercel Blob**.
+# vibe**blog**
 
-- **Framework:** Next.js 16 (App Router) + React 19 + TypeScript (strict)
-- **Storage:** Supabase Postgres for all text (`posts`/`pages`/`post_revisions`/`media`/`files`/`settings` tables; post bodies are Markdown in a text column); Vercel Blob for binaries only. Image refs stored store-relative (no vendor lock-in)
-- **Auth:** NextAuth v5 (Google OAuth), single authorized owner
-- **Editor:** TipTap 3 with Markdown; responsive images via `sharp` (original + AVIF/WebP variants, encoded in the background after save); a 3-version time machine per post
-- **Theming:** 6 built-in light+dark color palettes, each fully customizable; visitors can switch palette and light/dark/system/by-time mode; optional custom CSS
-- **Typography:** one tunable type system — every text role (h1–h5, body, small, caption, code) has its own size / line-height / letter-spacing, applied site-wide via CSS variables (no hardcoded sizes); upload a custom typeface per weight (Regular/Medium/SemiBold/Bold); one font for everything
-- **PWA:** installable to the iPhone/Android home screen, launches standalone (no service worker / no offline by design)
-- **Admin:** Overview with a System panel (hosting/region/env + database + storage); a toggleable activity log (Admin → Log) recording every save/upload/delete
-- **Trash:** every delete (posts, pages, media, files) is a recoverable soft delete; an Admin → Trash area restores or permanently removes items per type — nothing auto-purges
-- **Backups (optional):** connect Google Drive in Admin → Settings → Advanced to store full-site snapshots (database + all binaries in one `.tar.gz`); automatic on a schedule (default every 4 days, keep the latest 4), plus back-up-now / restore / delete. The Drive consent is separate from sign-in (`drive.file` scope) and the refresh token never leaves the server
-- **MCP server (optional):** a remote MCP endpoint (`/api/mcp`) lets an AI agent (Claude, ChatGPT) write and manage the blog with the same data layer as the admin UI. Toggle it on in Admin → Settings → Advanced and generate up to 5 named access tokens there (shown once, hashed at rest, revocable, expire after 180 days); a thin OAuth layer covers connectors that need it; sensitive settings are blocked
-- **UI languages:** en (default), vi, de, ja, zh, ko
-- **Styles:** Tailwind CSS v4
-- **Deploy:** Vercel (Docker self-host is on the [roadmap](./ROADMAP.md))
-- **Requires:** Node.js 20.9+ (Next 16)
+**An AI-operated personal blog platform.**
+Write and publish from a clean multilingual admin — or hand the keys to an AI agent and let it write, publish, and even deploy for you.
 
-## Local setup
+<br/>
 
-### Prerequisites
+![Next.js 16](https://img.shields.io/badge/Next.js_16-000000?logo=nextdotjs&logoColor=white)
+![React 19](https://img.shields.io/badge/React_19-20232a?logo=react&logoColor=61dafb)
+![TypeScript](https://img.shields.io/badge/TypeScript-3178c6?logo=typescript&logoColor=white)
+![Tailwind v4](https://img.shields.io/badge/Tailwind_v4-0b1120?logo=tailwindcss&logoColor=38bdf8)
+![Supabase](https://img.shields.io/badge/Supabase-3ecf8e?logo=supabase&logoColor=white)
+![Vercel](https://img.shields.io/badge/Vercel-000000?logo=vercel&logoColor=white)
+![MCP](https://img.shields.io/badge/MCP-ready-7c3aed)
+![License: MIT](https://img.shields.io/badge/License-MIT-22c55e)
+![Version](https://img.shields.io/badge/version-1.0.13-64748b)
 
-- **Node.js 20.9+** (Next 16) and npm.
-- A **Supabase** project (free tier is fine) — holds all text content.
-- A **Vercel Blob** store — holds binaries (images/files/icons). You need its
-  read/write token; you don't have to deploy to Vercel to use Blob locally.
-- A **Google OAuth app** — for admin sign-in.
+[**Get your own copy**](#-get-your-own-copy) · [**Let an AI run it**](#-let-an-ai-agent-write--publish-mcp) · [**Architecture**](./ARCHITECTURE.md) · [**Roadmap**](./ROADMAP.md) · [**License**](#-license)
 
-### Steps
+</div>
 
-1. **Clone + install**
+---
 
-   ```bash
-   git clone https://github.com/joiha-steven/vibeblog.git
-   cd vibeblog
-   npm install
-   ```
+## ✨ What it is
 
-2. **Create the database.** In your Supabase project open **SQL Editor → New query**,
-   paste the contents of [`scripts/schema.sql`](./scripts/schema.sql), and **Run**. This
-   creates every table, index, and RPC the app needs (idempotent — safe to re-run).
+A fast, single-owner blog where **all the writing happens in a polished `/admin`** (or over MCP), and the public site is statically cached for speed. Text lives in **Supabase Postgres**, binaries (images, files, icons) in **Vercel Blob** — no git push to publish, no CMS to wrangle.
 
-3. **Get your Supabase keys.** Supabase **Project Settings → API**: copy the
-   **Project URL** (`SUPABASE_URL`) and the **`service_role`** key
-   (`SUPABASE_SERVICE_ROLE_KEY` — secret, server-only).
+| | |
+|---|---|
+| 🖋️ **Editor** | TipTap 3 + Markdown · responsive `sharp` images (original + AVIF/WebP variants) · 3-version time machine · 60s autosave |
+| 🎨 **Look** | 6 customizable light+dark palettes · one tunable type system (per-role size/leading/tracking, no hardcoded sizes) · upload a custom font per weight |
+| 🌍 **i18n** | Admin + site in `en · vi · de · ja · zh · ko` |
+| 🔍 **Reading** | instant local + Postgres full-text search · ToC · related posts · reading time · progress bar |
+| 📈 **Built-in** | cookieless analytics (views / visitors / top pages, no PII) · activity log · soft-delete Trash (nothing auto-purges) |
+| 🔎 **SEO** | sitemap · RSS · `robots.txt` · `llms.txt` · dynamic OG images — all toggleable |
+| 💾 **Backups** | one-click full snapshots (DB + all binaries) to **Google Drive**, scheduled + restore |
+| 🤖 **MCP** | a remote endpoint that lets an AI agent write & manage the blog with the same rules as the admin |
+| 📱 **PWA** | installable, launches standalone |
+| 🔐 **Auth** | NextAuth v5 · Google sign-in · single authorized owner · edge-guarded admin/API |
 
-4. **Get a Blob token.** In the Vercel dashboard, **Storage → Create → Blob**, then in
-   the store's **`.env` / Tokens** tab copy the `BLOB_READ_WRITE_TOKEN`
-   (`vercel_blob_rw_…`). No need to deploy first.
+> Built on **Next.js 16** (App Router, React 19, strict TS) + **Tailwind v4**, deployed on **Vercel**.
 
-5. **Create a Google OAuth app.**
-   - [Cloud Console](https://console.cloud.google.com/) → Credentials →
-     OAuth client ID (Web). Authorized redirect URI:
-     `http://localhost:3000/api/auth/callback/google`.
+---
 
-6. **Configure env.**
+## 🚀 Get your own copy
 
-   ```bash
-   cp .env.example .env.local   # then fill in the values below
-   npx auth secret              # generates AUTH_SECRET — paste it in
-   ```
+Two ways to stand up your own blog — **pick one**. Both end with a live site at your domain.
 
-7. **Run it.**
+<details open>
+<summary><b>1️⃣ &nbsp;Do it yourself</b> &nbsp;— ~10 minutes in the dashboards</summary>
 
-   ```bash
-   npm run dev
-   ```
+<br/>
 
-   Open `http://localhost:3000/admin`, sign in as your `AUTHORIZED_EMAIL`, and set your
-   title / palette / menu in **Settings**. Start writing.
+1. **Fork** this repo (so Vercel deploys *your* copy).
+2. **Database** — create a [Supabase](https://supabase.com) project → SQL Editor → paste [`scripts/schema.sql`](./scripts/schema.sql) → **Run** (idempotent). Copy the **Project URL** + **`service_role`** key (Settings → API).
+3. **Import to Vercel** — *Add New → Project* → import your fork.
+4. **Blob store** — *Storage → Create → Blob*, connect it to the project. This injects `BLOB_READ_WRITE_TOKEN` automatically.
+5. **Env vars** (Settings → Environment Variables — see [the table](#-environment-variables)):
+   `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `AUTH_SECRET` (`npx auth secret`), `AUTHORIZED_EMAIL`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`.
+6. **Deploy.** Then on your [Google OAuth client](https://console.cloud.google.com/apis/credentials) add the redirect URI `https://<your-domain>/api/auth/callback/google`.
+7. Open `https://<your-domain>/admin`, sign in as `AUTHORIZED_EMAIL`, set your title / palette / menu in **Settings**, and start writing.
 
-### Required environment variables
+</details>
 
-See [`.env.example`](./.env.example). In short:
+<details>
+<summary><b>2️⃣ &nbsp;Hand it to an AI agent</b> &nbsp;— Claude, OpenAI Codex, OpenClaw, Hermes…</summary>
 
-| Variable                          | What it is                                |
-| --------------------------------- | ----------------------------------------- |
-| `AUTH_SECRET`                     | NextAuth secret — `npx auth secret`       |
-| `AUTHORIZED_EMAIL`                | The only email allowed into `/admin`      |
-| `AUTH_GOOGLE_ID` / `_SECRET`      | Google OAuth client                       |
-| `SUPABASE_URL`                    | Supabase project API URL                  |
-| `SUPABASE_SERVICE_ROLE_KEY`       | Supabase service_role key (secret, server-only) |
-| `BLOB_READ_WRITE_TOKEN`           | Vercel Blob read/write token              |
-| `CRON_SECRET`                     | Protects `/api/cron` (optional)           |
-| `MCP_OAUTH_SECRET`                | Signs MCP OAuth codes (optional; falls back to `AUTH_SECRET`). The MCP server is enabled and its tokens generated in Admin → Settings → Advanced — no token env var |
+<br/>
 
-Enable at least one provider; each loads only when its credentials are set. For
-production, register the same callback URLs against your live domain (see
-[Deploy to Vercel](#deploy-to-vercel)).
+Give an agent **Vercel + Supabase + GitHub access** (tokens / CLI / MCP), then paste:
 
-> **Note:** `BLOB_READ_WRITE_TOKEN` is also used to derive the public Blob store
-> URL at runtime — no extra env var needed. The token format
-> `vercel_blob_rw_<storeId>_<secret>` encodes the store ID directly.
+```text
+Deploy my own copy of github.com/joiha-steven/vibeblog:
+1. Fork the repo to my account.
+2. Create a Supabase project and run scripts/schema.sql in its SQL editor.
+3. Create a Vercel project from the fork; add a Vercel Blob store (this sets BLOB_READ_WRITE_TOKEN).
+4. Set env vars: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (Supabase → Settings → API),
+   AUTH_SECRET (generate with `npx auth secret`), AUTHORIZED_EMAIL=<my email>,
+   AUTH_GOOGLE_ID and AUTH_GOOGLE_SECRET (my Google OAuth "Web" client).
+5. Deploy, then register https://<domain>/api/auth/callback/google on the Google client.
+6. Return the live URL.
+```
 
-## Secrets & personal data
+> The one step an agent can't do alone is **creating the Google OAuth app** (it needs your Google login). Pre-create it, or grant access, and hand over the client ID/secret.
 
-This repo (`vibeblog`) is the **public, open-source platform** — MIT licensed,
-zero personal data. Anyone can fork and self-host.
+</details>
 
-Keep secrets out of git: your real credentials live in `.env.local` (gitignored
-via `.env*`) and on Vercel (retrieve any time with `vercel env pull`). Your actual
-blog content lives in Supabase Postgres + Vercel Blob, not in git. Don't commit personal data here.
+> [!TIP]
+> Two `vercel.json` knobs to make yours: `regions` (defaults to `sin1`/Singapore — set your nearest) and `maxDuration: 60` for uploads (the free Hobby plan caps function time, so trim it or upgrade to Pro for big photos).
 
-## Performance & caching
+---
 
-Public pages are **ISR-cached** (`revalidate`; `/[slug]` prerendered) so visitors get
-fast cached HTML, and **every admin save purges the affected pages** through one place
-(`src/lib/revalidate.ts`) — a new post refreshes the list/taxonomy surfaces, editing a
-post also refreshes its own page, and a settings change purges the whole site. Each
-purge is a deliberate superset of what a change can touch, so an edit (content, theme,
-anything) is live on the next request without ever under-purging. The Supabase reads are
-tagged `db` and every save calls `revalidateTag('db')`, so a re-rendered page always reads
-fresh from Postgres (never a stale Data Cache entry). Admin is fully dynamic (uncached);
-editor saves also `router.refresh()`, and a "Clear all cache" button purges + warms on
-demand. Functions run in Singapore (`vercel.json` pins `sin1`), co-located with the
-Supabase project (ap-southeast-1); images keep a 1-year CDN cache on the Blob host. List
-pages use **path-based pagination** (`/page/2`,
-`/category/x/page/2` — no `?query`). Uploaded photos keep the untouched original and
-serve responsive AVIF/WebP variants (`<picture>`, only once the variants exist).
+## 🤖 Let an AI agent write & publish (MCP)
 
-See [`ARCHITECTURE.md`](./ARCHITECTURE.md) for the full design and the *why*.
+vibeblog ships a remote **MCP** server, so a second AI agent can run your blog — drafting, editing, tagging, and **publishing straight to the live site**. No git, no deploy: content goes into Supabase + Blob through the same data layer (and same slug/revision/soft-delete rules) the admin uses.
 
-## Deploy to Vercel
+1. **Turn it on** — *Admin → Settings → Advanced → MCP*, generate a named token (shown **once**, hashed at rest, expires in 180 days).
+2. **Connect your agent** to the endpoint `https://<your-domain>/api/mcp` with `Authorization: Bearer <token>` (OAuth connectors are supported too).
+3. **Prompt it**, e.g.:
 
-vibeblog is built for Vercel. Two ways to install your own copy: do it yourself in
-the dashboard, or hand the whole job to an AI agent.
+```text
+Using the vibeblog MCP server, write a 600-word post titled
+"What I learned shipping a blog with an AI agent", give it the tags
+"ai" and "writing", set a friendly excerpt, and publish it.
+```
 
-### A. Manual (Vercel dashboard)
+The post is live in seconds. Sensitive settings are blocked over MCP, and you stay the sole authority — revoke any token from the admin and it's gone.
 
-1. **Fork** this repo on GitHub (so you own the copy Vercel deploys).
-2. **Create the database.** In a [Supabase](https://supabase.com) project, run
-   [`scripts/schema.sql`](./scripts/schema.sql) in the SQL Editor (creates all tables +
-   RPCs). Note the **Project URL** and **`service_role`** key (Project Settings → API).
-3. In Vercel: **Add New → Project**, then import your fork.
-4. **Storage → Create → Blob**, and connect the store to the project. This injects
-   `BLOB_READ_WRITE_TOKEN` automatically — the only storage config you need.
-5. Add the rest under **Settings → Environment Variables** (see `.env.example`):
-   - `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` — from step 2.
-   - `AUTH_SECRET` — run `npx auth secret` and paste the output.
-   - `AUTHORIZED_EMAIL` — the single email allowed into `/admin`.
-   - Google OAuth: `AUTH_GOOGLE_ID` + `AUTH_GOOGLE_SECRET`.
-6. **Deploy.**
-7. **Register the OAuth callback URL** with Google, using the live domain:
-   - `https://<your-domain>/api/auth/callback/google`
+---
 
-   Add both your `*.vercel.app` URL and any custom domain.
-8. Open `https://<your-domain>/admin`, sign in as `AUTHORIZED_EMAIL`, and set your
-   title / palette / menu in **Settings**. That's it — start writing.
+## 🔑 Environment variables
 
-> **Two `vercel.json` settings to adjust for yourself:**
-> - `regions: ["sin1"]` pins functions to **Singapore** — that is simply the original
->   author's nearest region (a Vietnam audience), not a requirement. **Change it to your
->   own nearest region**, or delete the `regions` line to let Vercel pick automatically.
-> - `maxDuration: 60` gives image uploads up to 60s. That can exceed the **free (Hobby)**
->   plan's function limit, so very large photo uploads may time out — lower it, keep
->   images modest, or upgrade to Pro.
+See [`.env.example`](./.env.example). The essentials:
 
-### B. Via an AI agent (OpenClaw, Hermes, Claude, …)
+| Variable | What it is |
+|---|---|
+| `AUTH_SECRET` | NextAuth secret — `npx auth secret` |
+| `AUTHORIZED_EMAIL` | The only email allowed into `/admin` |
+| `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` | Google OAuth "Web" client (admin sign-in) |
+| `SUPABASE_URL` | Supabase project API URL |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase `service_role` key (secret, server-only) |
+| `BLOB_READ_WRITE_TOKEN` | Vercel Blob token — also derives the public Blob URL at runtime |
+| `CRON_SECRET` | Protects `/api/cron` (keep-alive + scheduled backup) — optional |
+| `MCP_OAUTH_SECRET` | Signs MCP OAuth codes — optional, falls back to `AUTH_SECRET` |
 
-Rather not click through Vercel? Hand it to any AI agent that can act on **Vercel**
-and **Supabase** (through their API / CLI / MCP) and **GitHub**. Give the agent:
+MCP tokens and the Google Drive backup connection are **created in the admin**, not via env. Secrets stay in `.env.local` (gitignored) + Vercel (`vercel env pull`); your blog content lives in Supabase + Blob, never in git.
 
-- this repository URL (to fork + import),
-- your `AUTHORIZED_EMAIL`,
-- your OAuth app credentials (or let it create the OAuth app if it has provider access),
-- a **Vercel token** (Account → Settings → Tokens), **Supabase** access, and GitHub access.
+---
 
-Then ask it to: *fork the repo, create a Supabase project and run `scripts/schema.sql`
-on it, create a Vercel project from the fork, add a Blob store, generate `AUTH_SECRET`,
-set the environment variables above (incl. `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`),
-deploy, and return the live URL.* Finish by registering the OAuth callback URL (step 7
-above) and signing in at `/admin`. The only step an agent can't do alone is the OAuth
-**provider** setup (it needs your Google login) — pre-create that app, or grant access.
+## 🧑‍💻 Run locally (optional)
 
-## Usage
+```bash
+git clone https://github.com/joiha-steven/vibeblog.git && cd vibeblog
+npm install
+cp .env.example .env.local        # fill in the values above
+npx auth secret                   # AUTH_SECRET
+npm run dev                       # http://localhost:3000/admin
+```
 
-- `/` — public blog (published, date-reached posts only); posts get Shiki-highlighted code,
-  intrinsic-sized (CLS-free) images, and a back-to-top button
-- Header search opens an in-place overlay (instant local title/tag + full-text body search via
-  Postgres `tsvector`); `/search` still works for deep links · `/category/<x>`, `/tag/<x>` — taxonomy lists
-- `/admin` — dashboard (owner only); `/admin/editor`, `/admin/media`, `/admin/analytics`,
-  `/admin/settings`. Built-in cookieless analytics (views / unique visitors / top pages, no PII)
-- SEO / feeds (toggleable in Settings → SEO): `/sitemap.xml`, `/robots.txt`,
-  `/feed.xml` (RSS), `/llms.txt`, `/og` (dynamic share image)
+Point the same Supabase + Blob at local, and add `http://localhost:3000/api/auth/callback/google` to your Google client. `npm run build` + `npm run lint` must both pass (strict `tsc`, no `any`).
 
-### Settings (`/admin/settings`)
+---
 
-One form, one Save button, three tabs:
+## ⚙️ Using it
 
-- **General** — site title / description / language, logo + favicon + app icon, content width &
-  posts-per-page, header menu, reader features (search, ToC, related, reading time, progress bar,
-  activity log), and SEO toggles.
-- **Appearance** — colors (pick any of the 6 palettes and edit its light+dark colors; set the
-  visitor default), the custom **font** (upload one file per weight: Regular / Medium / SemiBold /
-  Bold — all share one family, Inter is the fallback), and the **text sizes** table (size /
-  line-height / letter-spacing for every role: h1–h5, body, small, caption, code). One "reset to
-  default" restores the tuned scale.
-- **Advanced** — font smoothing (anti-aliasing) toggle and custom CSS.
+- `/` — public blog (published, date-reached posts) · `/category/<slug>`, `/tag/<slug>` (slugified) · header search overlay · path-based pagination (`/page/2`).
+- `/admin` — dashboard, editor, media, analytics, settings (owner only).
+- **Settings** is one form / one Save, three tabs — **General** (site, menu, reader features, SEO), **Appearance** (palettes, custom font, the per-role text-size table), **Advanced** (MCP, backups, custom CSS). Everything is injected as CSS variables, so changes apply site-wide with **no redeploy**.
+- **Performance:** public pages are ISR-cached; every admin save purges exactly the affected pages through one place ([`src/lib/revalidate.ts`](./src/lib/revalidate.ts)), so edits are live next request without ever serving stale. Full design + the *why* in [`ARCHITECTURE.md`](./ARCHITECTURE.md).
 
-Everything is stored in the single `settings` row and injected as CSS variables, so changes apply
-site-wide with no redeploy.
+---
 
-## Roadmap
+## 🗺️ Roadmap
 
-Planned: Docker self-host (pluggable S3/MinIO/local storage), publishing from Markdown
-note apps (Obsidian, then Craft), and optional AI assist in the editor. See
-[`ROADMAP.md`](./ROADMAP.md).
+Docker self-host (pluggable S3/MinIO/local storage), publishing from Markdown note apps (Obsidian → Craft), and optional AI assist in the editor. See [`ROADMAP.md`](./ROADMAP.md).
 
-## License
+---
+
+## 📄 License
 
 Two separate layers — keep them distinct:
 
-- **Code (this repository) — [MIT](./LICENSE).** Free and open source. Use, modify,
-  redistribute, or sell it freely, for any purpose, with **no obligation to credit**
-  the author (MIT only asks that the license text travels with copies of the source).
-  Fork it and run your own blog.
-- **Content — © all rights reserved.** The blog content published *with* vibeblog
-  (articles, images, and other writing on an operator's site, e.g. manhhung.me) is the
-  property of its author and is **not** covered by the MIT license. It does not live in
-  this repository and may not be reused without permission.
+- **Code (this repo) — [MIT](./LICENSE).** Free and open source: use, modify, redistribute, or sell it for any purpose, **no obligation to credit** (MIT only asks the license text travels with copies of the source). Fork it and run your own blog.
+- **Content — © all rights reserved.** The writing published *with* vibeblog (articles, images on an operator's site, e.g. manhhung.me) belongs to its author, is **not** covered by MIT, does not live in this repo, and may not be reused without permission.
 
-In short: the **software** is open for anyone; the **author's writing** is not.
+> In short: the **software** is open for anyone; the **author's writing** is not.


### PR DESCRIPTION
Rewrites the README to be tighter, more complete, and far better looking — centered header + shields.io badges + a scannable feature table + GitHub alerts/collapsibles (inspired by the rahul-jha98 / thaiane profile READMEs).

**Canonical install guide is now two paths** (per project rule):
1. **Do it yourself** — dashboard deploy (Supabase + Vercel + Blob + env), collapsible.
2. **Hand it to an AI agent** — a copy-paste prompt for Claude / OpenAI Codex / OpenClaw / Hermes to fork + deploy.

Plus a new **"Let an AI agent write & publish (MCP)"** section: enable MCP, mint a token, point an agent at `/api/mcp`, and it publishes straight to the live blog (no git/deploy).

"Run locally" is now a small optional aside, not the headline. Version moved to a badge; `CLAUDE.md` updated to record the rule (keep README install/MCP/env current on any setup change) and the badge-bump.

Docs only — no code, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)