### PR TITLE
fix(backup): stale 'Connect' state after connecting Google Drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 2026-06-22 (v1.0.14 — fix Backups card stuck on "Connect" after connecting)
+- **fix(backup): the Backups card kept showing "Connect Google Drive" after a successful
+  connect** (and "Back up now" stayed disabled). Root cause: the `backup_state` read is Data-Cache-
+  eligible (tag `db`, 1h), and the connect write (`setDriveAuth`) didn't `revalidateTag('db')`, so
+  `GET /api/backup` served the stale pre-connect "not connected" state until the cache expired.
+  `setDriveAuth` / `clearDriveAuth` / `setFolderId` / `recordRun` now bust the `db` tag, so the
+  admin reflects connect / disconnect / run / last-status immediately (confirmed via Supabase API
+  logs: no `backup_state` re-read occurred after the connect writes). Also added a focus/visibility
+  refetch to `BackupFields` so it re-syncs after the OAuth round-trip. `v1.0.14`.
+
 ## 2026-06-22 (v1.0.13 — fix Drive connect redirect + tidy Backups layout)
 - **fix(backup): `redirect_uri_mismatch` connecting Google Drive.** The consent + token-exchange
   redirect URI was built from `req.nextUrl.origin`, which is a `*.vercel.app` host when the admin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,11 @@ are called out elsewhere (Caching, Typography, Conventions).
   (`enabled`/`intervalDays`/`keep`) lives in `settings.backups` and flows through the settings
   form; the connection + snapshot list come from owner-only `/api/backup` (returns `toStatus`,
   never the token) — same split as MCP tokens.
+- **`backup_state` writes MUST `revalidateTag(DB_TAG, 'max')`** (`backup-state.ts`:
+  `setDriveAuth`/`clearDriveAuth`/`setFolderId`/`recordRun`). The state read is Data-Cache-eligible
+  (tag `db`, 1h) and is read by BOTH `/api/backup` and the admin Overview — `force-dynamic` on one
+  route is NOT enough to dodge the *shared* Data Cache, so without busting it the admin showed stale
+  "not connected" after a successful connect (the bug that shipped in 1.0.11–1.0.13).
 - **Restore is DESTRUCTIVE** (`POST /api/backup/restore`): replaces every text table (settings
   upserted by id=1; others delete-all then insert with `id`/`search` stripped) and re-uploads
   every blob. A **pre-restore snapshot is taken first**. UI confirms before calling.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# vibe**blog** &nbsp;`v1.0.13`
+# vibe**blog** &nbsp;`v1.0.14`
 
 **An AI-operated personal blog platform.**
 Write and publish from a clean multilingual admin — or hand the keys to an AI agent and let it write, publish, and even deploy for you.
@@ -26,9 +26,11 @@ Write and publish from a clean multilingual admin — or hand the keys to an AI 
 
 ## ✨ What it is
 
-A fast, single-owner blog where **all the writing happens in a polished `/admin`** (or over MCP), and the public site is statically cached for speed. Text lives in **Supabase Postgres**, binaries (images, files, icons) in **Vercel Blob** — no git push to publish, no CMS to wrangle.
+An **open-source** (MIT), single-owner blog built for people who just want to **write**. The public site is statically cached so it loads **insanely fast on mobile and desktop**, and it's tuned around **readable typography** — a clean reading experience first. Everything is **easy to tweak from the admin** (palettes, type, menu, fonts) with **no hardcoded values** anywhere, so you make it yours without touching code.
 
-| &nbsp; | &nbsp; |
+All the writing happens in a polished `/admin` (or over MCP). Text lives in **Supabase Postgres**, binaries (images, files, icons) in **Vercel Blob** — no git push to publish, no CMS to wrangle.
+
+| Area | What you get |
 |:---|:---|
 | 🖋️&nbsp;**Editor** | TipTap 3 + Markdown · responsive `sharp` images (original + AVIF/WebP variants) · 3-version time machine · 60s autosave |
 | 🎨&nbsp;**Look** | 6 customizable light+dark palettes · one tunable type system (per-role size/leading/tracking, no hardcoded sizes) · upload a custom font per weight |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeblog",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "private": true,
   "license": "MIT",
   "browserslist": [

--- a/src/components/admin/BackupFields.tsx
+++ b/src/components/admin/BackupFields.tsx
@@ -52,6 +52,19 @@ export function BackupFields({ backups, onChange }: { backups: BackupSettings; o
       .catch(() => {})
   }, [])
 
+  // Re-sync when the owner returns to the tab — connecting Drive happens via a
+  // full-page OAuth round-trip, so refetch on focus to reflect it without a manual
+  // reload (listeners only — no setState in the body).
+  useEffect(() => {
+    const onFocus = () => { if (document.visibilityState === 'visible') refresh() }
+    window.addEventListener('focus', onFocus)
+    document.addEventListener('visibilitychange', onFocus)
+    return () => {
+      window.removeEventListener('focus', onFocus)
+      document.removeEventListener('visibilitychange', onFocus)
+    }
+  }, [refresh])
+
   // Show a toast for the Drive connect redirect result (?backup=connected|error).
   useEffect(() => {
     const p = new URLSearchParams(window.location.search).get('backup')

--- a/src/lib/backup-state.ts
+++ b/src/lib/backup-state.ts
@@ -4,7 +4,8 @@
 // settings; the token, the Drive folder id, and last-run state live here in the
 // `backup_state` table (single row id=1). Never import this from a client component.
 
-import { db } from '@/lib/db'
+import { revalidateTag } from 'next/cache'
+import { db, DB_TAG } from '@/lib/db'
 
 export type BackupState = {
   refreshToken: string | null
@@ -79,16 +80,19 @@ export function toStatus(s: BackupState): BackupStatus {
 // Store the Drive refresh token (from the consent callback). folderId stays as-is.
 export async function setDriveAuth(refreshToken: string): Promise<void> {
   await db().from('backup_state').upsert({ id: 1, refresh_token: refreshToken })
+  revalidateTag(DB_TAG, 'max') // bust the cached read so the admin sees "connected" at once
 }
 
 // Remember the snapshot folder once created so we reuse it.
 export async function setFolderId(folderId: string): Promise<void> {
   await db().from('backup_state').upsert({ id: 1, folder_id: folderId })
+  revalidateTag(DB_TAG, 'max')
 }
 
 // Disconnect Drive: forget the token + folder (snapshots already on Drive stay).
 export async function clearDriveAuth(): Promise<void> {
   await db().from('backup_state').upsert({ id: 1, refresh_token: null, folder_id: null })
+  revalidateTag(DB_TAG, 'max')
 }
 
 // Stamp the outcome of a backup run for the admin status panel.
@@ -100,4 +104,5 @@ export async function recordRun(status: 'success' | 'error', error: string | nul
     last_error: error,
     last_size: size,
   })
+  revalidateTag(DB_TAG, 'max')
 }


### PR DESCRIPTION
The Backups card kept showing **Connect Google Drive** after a successful connect (and *Back up now* stayed disabled). Root cause confirmed via Supabase API logs: `backup_state` reads are Data-Cache-eligible (tag `db`, 1h) and the connect write didn't `revalidateTag`, so `GET /api/backup` served the stale pre-connect state.

- `setDriveAuth`/`clearDriveAuth`/`setFolderId`/`recordRun` now `revalidateTag(DB_TAG, 'max')`.
- `BackupFields` refetches on focus/visibility to re-sync after the OAuth round-trip.

Build + lint + typecheck pass. v1.0.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)