### PR TITLE
fix(ios): reading progress bar reaches top edge on notch/Dynamic Island

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
 
-## 2026-06-22 (v1.0.15 — README: clearer "What it is" + friendlier install)
+## 2026-06-23 (v1.0.16 — reading progress bar reaches the top edge on notch/Dynamic Island)
+- **fix(ios): the reading progress bar sat below the Dynamic Island / notch instead of at the
+  true top edge.** Without `viewport-fit=cover`, iOS Safari lays the page out inside the safe area,
+  so the bar's `top: 0` landed at the top of the *content* area (under the island), looking like it
+  floated mid-screen. Set `viewportFit: 'cover'` in `generateViewport` so the page fills under the
+  island and the fixed bar reaches the real top edge, and added `env(safe-area-inset-*)` padding on
+  `body` so the header/content re-clear the island (env() is 0 on devices without insets, so no
+  effect elsewhere). `v1.0.16`.
 - **docs(readme): rewrote "What it is"** to lead with the actual pitch — open-source (MIT),
   built for people who just want to **write**, **fast load on mobile + desktop**, **readable
   typography**, and **easy to tweak from the admin with no hardcoded values**. Gave the feature

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,6 +424,11 @@ are called out elsewhere (Caching, Typography, Conventions).
 - iOS home-screen icon = the **apple-touch-icon** (`generateMetadata` in `app/layout.tsx`);
   standalone via the manifest's `display:standalone` (iOS 16.4+). Status bar via
   `generateViewport` → `themeColor`.
+- **Notch / Dynamic Island:** `generateViewport` sets `viewportFit: 'cover'` so the page fills
+  under the island and fixed top bars (the reading-progress bar) reach the true screen edge;
+  `body` re-pads with `env(safe-area-inset-*)` (globals.css) so the header/content clear the
+  island. `env()` is 0 on devices without insets — no effect there. Don't remove one without the
+  other (cover alone tucks the header under the island; padding alone leaves the bar below it).
 - App icon order: `appIconUrl` → `faviconUrl` → bundled `public/app-icon.png`.
 - **Favicon: ONE `<link rel="icon">`, driven only by `generateMetadata`** (`settings.faviconUrl ||
   '/favicon.ico'`). The default lives in **`public/favicon.ico`, NOT `app/`** — an `app/favicon.ico`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# vibe**blog** &nbsp;`v1.0.15`
+# vibe**blog** &nbsp;`v1.0.16`
 
 **An AI-operated personal blog platform.**
 Write and publish from a clean multilingual admin — or hand the keys to an AI agent and let it write, publish, and even deploy for you.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeblog",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "private": true,
   "license": "MIT",
   "browserslist": [

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -115,6 +115,11 @@ body {
   letter-spacing: var(--ls-body, 0em);
   background: var(--c-bg);
   color: var(--c-text);
+  /* viewport-fit=cover (root layout) lets the page fill under the notch / Dynamic
+     Island so fixed top bars (reading progress) reach the true top edge. Re-pad the
+     content past the safe area here so the header/text never sit under the island.
+     env() is 0 on devices without insets, so this is a no-op there. */
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) 0 env(safe-area-inset-left);
 }
 
 /* Selection feels intentional and on-brand (monochrome). */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,6 +34,10 @@ export async function generateViewport(): Promise<Viewport> {
   const { themes, themePreset } = await getSettings()
   const theme = getDefaultTheme(themes, themePreset)
   return {
+    // Extend the page under the notch / Dynamic Island so a fixed top bar (the
+    // reading progress) sits flush at the true screen edge; `body` re-pads the
+    // content past the safe area (globals.css) so the header never tucks under it.
+    viewportFit: 'cover',
     themeColor: [
       { media: '(prefers-color-scheme: light)', color: theme.light.bg },
       { media: '(prefers-color-scheme: dark)', color: theme.dark.bg },


### PR DESCRIPTION
The reading progress bar sat *below* the Dynamic Island / notch instead of at the true top edge.

**Cause:** no `viewport-fit=cover`, so iOS Safari lays the page out inside the safe area and the bar's `top: 0` lands at the top of the content area (under the island).

**Fix:**
- `generateViewport` → `viewportFit: 'cover'` so the page fills under the island and the fixed bar reaches the real top edge.
- `body` gets `env(safe-area-inset-*)` padding so the header/content re-clear the island. `env()` is 0 on devices without insets, so no effect elsewhere.

Verified `npm run lint` + `npm run build` both exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)