### PR TITLE
fix(admin): force-no-store on admin live reads (fixes stale MCP token list)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## 2026-06-23 (v1.0.17 — admin live reads were silently served from the 1h Data Cache)
+- **fix(admin): the MCP token list (and every admin live read) could show STALE data —
+  most visibly "list token không hiện" after connecting a connector from Claude.** Root cause:
+  `dynamic = 'force-dynamic'` does NOT de-cache our `db()` GET reads, because they opt into the
+  Data Cache with an explicit `next: { revalidate, tags:['db'] }` — Next only auto-de-caches
+  force-dynamic fetches that set NO revalidate (`noFetchConfigAndForceDynamic` in `patch-fetch`).
+  So a tagged read stayed in the 1h Data Cache, and an OAuth token minted out-of-band (which
+  intentionally does not purge tag `db`) never appeared. Added `export const fetchCache =
+  'force-no-store'` — the lever that forces every fetch in a segment to `no-store` regardless of
+  its options — to the `/admin` layout (cascades to all admin pages) and the owner-only live API
+  routes (`api/mcp/tokens`, `api/files`, `api/media`, `api/media/unused`,
+  `api/posts/[slug]/revisions`, `api/backup`). Public pages keep their cached/ISR reads (they set
+  neither config). Same class of bug as the 1.0.11–1.0.13 "Backups stuck on Connect". `v1.0.17`.
+
 ## 2026-06-23 (v1.0.16 — reading progress bar reaches the top edge on notch/Dynamic Island)
 - **fix(ios): the reading progress bar sat below the Dynamic Island / notch instead of at the
   true top edge.** Without `viewport-fit=cover`, iOS Safari lays the page out inside the safe area,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,14 +107,21 @@ THEN a `revalidatePath` SUPERSET (which pages re-render):
 Other rules:
 - Admin forms `router.refresh()` after save; admin routes are `force-dynamic` (their DB
   reads become `no-store` → editor/media/settings always live).
-- **GOTCHA — owner-only API LIST routes fetched from a client component MUST export
-  `dynamic = 'force-dynamic'`.** They are NOT under the `/admin` layout, so without it
-  their `db()` GET reads stay Data-Cache-eligible (tag `db`, 1h) and the client list shows
-  STALE rows after a mutation (this caused "deleting an MCP token does nothing" — the
-  cached list kept showing a deleted id). Applies to `api/mcp/tokens`, `api/files`,
-  `api/media`, `api/media/unused`, `api/posts/[slug]/revisions`. Token CRUD intentionally
-  does NOT `revalidateTag('db')` (that would over-purge public pages) — `force-dynamic` is
-  the right tool: live admin read, zero public-cache impact.
+- **GOTCHA — admin LIVE reads need `fetchCache = 'force-no-store'`, NOT just
+  `dynamic = 'force-dynamic'`.** Our `db()` GET reads opt into the Data Cache with an
+  explicit `next: { revalidate, tags:['db'] }`. `force-dynamic` does NOT de-cache those —
+  Next only auto-de-caches force-dynamic fetches that set NO revalidate (the
+  `noFetchConfigAndForceDynamic` path in `patch-fetch.js`); an explicit `revalidate`
+  survives. So a tagged read stays in the 1h Data Cache and shows STALE rows after a
+  mutation — especially OUT-OF-BAND ones that don't purge tag `db` (MCP/OAuth token
+  mints from Claude, cron backup state). `fetchCache = 'force-no-store'` is the lever that
+  forces EVERY fetch in the segment to `no-store` regardless of its options. Set BOTH on:
+  the `/admin` layout (cascades to all admin pages) and the owner-only list API routes
+  (NOT under `/admin`): `api/mcp/tokens`, `api/files`, `api/media`, `api/media/unused`,
+  `api/posts/[slug]/revisions`, `api/backup`. Token CRUD intentionally does NOT
+  `revalidateTag('db')` (that would over-purge public pages) — `force-no-store` gives a
+  live admin read with zero public-cache impact. (This caused "list token không hiện"
+  after an OAuth connect, and earlier the "backup shows not-connected" bug 1.0.11–1.0.13.)
 - `experimental.staleTimes: { dynamic: 0, static: 30 }` (Next 16 rejects `static: 0`).
 - **Accepted staleness:** the "related posts" box on OTHER posts (≤1h ISR / next save).
 - **DO NOT** set the Supabase GET reads to `cache: 'no-store'` (forces every page dynamic,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# vibe**blog** &nbsp;`v1.0.16`
+# vibe**blog** &nbsp;`v1.0.17`
 
 **An AI-operated personal blog platform.**
 Write and publish from a clean multilingual admin — or hand the keys to an AI agent and let it write, publish, and even deploy for you.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeblog",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "private": true,
   "license": "MIT",
   "browserslist": [

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -8,9 +8,17 @@ import { paletteOptions } from '@/lib/themes'
 import { AdminI18nProvider } from '@/components/admin/I18nProvider'
 import { AdminSidebar } from '@/components/admin/AdminSidebar'
 
-// The entire admin is uncached — every view reads the current Blob state, so the
-// editor/media library/settings never show a stale snapshot of your own edits.
+// The entire admin is uncached — every view reads the CURRENT DB, so it never shows
+// a stale snapshot (your own edits, or out-of-band changes like MCP/OAuth tokens,
+// analytics, or a cron backup). NOTE: `dynamic = 'force-dynamic'` alone is NOT enough:
+// our db() GET reads opt into the Data Cache with an explicit `next.revalidate`+tag,
+// and force-dynamic only de-caches fetches that set NO revalidate (see Next's
+// `noFetchConfigAndForceDynamic` in patch-fetch). `fetchCache = 'force-no-store'` is the
+// lever that forces EVERY fetch in this segment to no-store regardless of its options;
+// it cascades to all /admin children. (Public pages keep their cached reads — they set
+// neither config.)
 export const dynamic = 'force-dynamic'
+export const fetchCache = 'force-no-store'
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
   const { email, authorized } = await getAuthState()

--- a/src/app/api/backup/route.ts
+++ b/src/app/api/backup/route.ts
@@ -11,8 +11,13 @@ import { ok, fail, logRequest, logError, requireOwner } from '@/lib/api'
 
 // A full snapshot streams every blob through the function — give it headroom.
 export const maxDuration = 300
-// Owner-only live data: the snapshot list must reflect Drive immediately.
+// Owner-only live data: the snapshot list + connection status must reflect Drive/DB
+// immediately. db() GET reads are Data-Cache-eligible (tag 'db', 1h) and force-dynamic
+// alone does NOT de-cache them (they set an explicit next.revalidate); `fetchCache =
+// 'force-no-store'` forces a live read. (The backup_state writers still purge tag 'db'
+// for the public-cache side — see backup-state.ts.)
 export const dynamic = 'force-dynamic'
+export const fetchCache = 'force-no-store'
 
 export async function GET(req: NextRequest): Promise<Response> {
   const start = Date.now()

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -6,9 +6,11 @@ import type { NextRequest } from 'next/server'
 import { getFiles } from '@/lib/files'
 import { ok, fail, logRequest, logError, requireOwner } from '@/lib/api'
 
-// Admin-only live data: db() GET reads are Data-Cache-eligible (tag 'db', 1h), so
-// without this the list stays stale after an upload/delete. Force a live read.
+// Admin-only live data: db() GET reads are Data-Cache-eligible (tag 'db', 1h). force-dynamic
+// alone does NOT de-cache them (they set an explicit next.revalidate) — `fetchCache =
+// 'force-no-store'` forces a live read so the list stays current after an upload/delete.
 export const dynamic = 'force-dynamic'
+export const fetchCache = 'force-no-store'
 
 export async function GET(req: NextRequest): Promise<Response> {
   const start = Date.now()

--- a/src/app/api/mcp/tokens/route.ts
+++ b/src/app/api/mcp/tokens/route.ts
@@ -7,10 +7,14 @@ import { listTokens, createToken } from '@/lib/mcp/tokens'
 import { logActivity } from '@/lib/activity'
 import { ok, fail, logRequest, logError, requireOwner } from '@/lib/api'
 
-// Admin-only live data: the GET list must reflect the DB immediately (creates +
-// OAuth mints + deletes happen out-of-band). Without this, db() GET reads are
-// Data-Cache-eligible (tag 'db', 1h) → the list shows deleted/stale tokens.
+// Admin-only live data: the GET list must reflect the DB immediately (manual creates +
+// OAuth connector mints + deletes happen OUT-OF-BAND, e.g. from Claude, and do NOT purge
+// tag 'db'). db() GET reads opt into the Data Cache via an explicit `next.revalidate`+tag,
+// which `dynamic = 'force-dynamic'` does NOT override (it only de-caches fetches with no
+// revalidate). `fetchCache = 'force-no-store'` forces this route's reads to no-store, so a
+// freshly OAuth-connected token shows up at once. (This was the "list token không hiện" bug.)
 export const dynamic = 'force-dynamic'
+export const fetchCache = 'force-no-store'
 
 export async function GET(req: NextRequest): Promise<Response> {
   const start = Date.now()

--- a/src/app/api/media/route.ts
+++ b/src/app/api/media/route.ts
@@ -4,9 +4,11 @@ import type { NextRequest } from 'next/server'
 import { getMedia } from '@/lib/media'
 import { ok, fail, logRequest, logError, requireOwner } from '@/lib/api'
 
-// Admin-only live data: db() GET reads are Data-Cache-eligible (tag 'db', 1h), so
-// without this the library stays stale after an upload/delete. Force a live read.
+// Admin-only live data: db() GET reads are Data-Cache-eligible (tag 'db', 1h). force-dynamic
+// alone does NOT de-cache them (they set an explicit next.revalidate) — `fetchCache =
+// 'force-no-store'` forces a live read so the library stays current after an upload/delete.
 export const dynamic = 'force-dynamic'
+export const fetchCache = 'force-no-store'
 
 export async function GET(req: NextRequest): Promise<Response> {
   const start = Date.now()

--- a/src/app/api/media/unused/route.ts
+++ b/src/app/api/media/unused/route.ts
@@ -6,9 +6,11 @@ import type { NextRequest } from 'next/server'
 import { findUnusedMedia } from '@/lib/media-usage'
 import { ok, fail, logRequest, logError, requireOwner } from '@/lib/api'
 
-// Admin-only live audit: db() GET reads are Data-Cache-eligible (tag 'db', 1h);
-// force a live read so the "unused" set reflects the current DB.
+// Admin-only live audit: db() GET reads are Data-Cache-eligible (tag 'db', 1h). force-dynamic
+// alone does NOT de-cache them (they set an explicit next.revalidate) — `fetchCache =
+// 'force-no-store'` forces a live read so the "unused" set reflects the current DB.
 export const dynamic = 'force-dynamic'
+export const fetchCache = 'force-no-store'
 
 // Reads every post/page body plus revision snapshots to collect references.
 export const maxDuration = 60

--- a/src/app/api/posts/[slug]/revisions/route.ts
+++ b/src/app/api/posts/[slug]/revisions/route.ts
@@ -5,9 +5,11 @@ import type { NextRequest } from 'next/server'
 import { getRevisions } from '@/lib/revisions'
 import { ok, fail, logRequest, logError, requireOwner } from '@/lib/api'
 
-// Admin-only live data: db() GET reads are Data-Cache-eligible (tag 'db', 1h);
-// force a live read so the time-machine list shows the latest snapshots.
+// Admin-only live data: db() GET reads are Data-Cache-eligible (tag 'db', 1h). force-dynamic
+// alone does NOT de-cache them (they set an explicit next.revalidate) — `fetchCache =
+// 'force-no-store'` forces a live read so the time-machine list shows the latest snapshots.
 export const dynamic = 'force-dynamic'
+export const fetchCache = 'force-no-store'
 
 export async function GET(req: NextRequest, ctx: RouteContext<'/api/posts/[slug]/revisions'>): Promise<Response> {
   const start = Date.now()

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -15,8 +15,11 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 //   whole route dynamic, killing the page cache). They are tagged `db`, and EVERY
 //   admin write calls `revalidateTag('db')` (see revalidate.ts) — so when a purged
 //   page re-renders it always reads CURRENT data, never a stale Data Cache entry.
-//   The 3600s revalidate is just a safety net. On a force-dynamic route (all of
-//   /admin) Next overrides reads to `no-store`, so the editor always sees live data.
+//   The 3600s revalidate is just a safety net. Admin surfaces that must read LIVE
+//   (the /admin layout + the owner-only list API routes) set BOTH `dynamic =
+//   'force-dynamic'` AND `fetchCache = 'force-no-store'` — force-dynamic ALONE does not
+//   de-cache these reads, because they opt into the Data Cache with an explicit
+//   `next.revalidate` (Next only auto-de-caches force-dynamic fetches that set none).
 // - WRITES (POST/PATCH/DELETE/etc.) are `no-store` — never cached.
 export const DB_TAG = 'db'
 const REVALIDATE = 3600


### PR DESCRIPTION
## Problem
Connecting the vibeblog MCP connector from Claude succeeded (tokens are minted and used), but **the admin token list stayed empty** ("list token không hiện"). Root cause is broader than tokens: **every admin live read could be served stale from the 1h Data Cache.**

## Root cause
`export const dynamic = 'force-dynamic'` does **not** de-cache our `db()` GET reads. Those reads opt into the Data Cache with an explicit `next: { revalidate: 3600, tags: ['db'] }`. Per Next 16's `patch-fetch.js`, force-dynamic only auto-de-caches fetches that set **no** revalidate (the `noFetchConfigAndForceDynamic` branch) — an explicit `revalidate` survives. So a tagged read sits in the 1h Data Cache, and an OAuth token minted **out-of-band** (which intentionally does not `revalidateTag('db')`, to avoid over-purging public pages) never appears until the entry expires.

Same class of bug as the 1.0.11–1.0.13 "Backups stuck on Connect", which was patched there by manually purging the tag.

## Fix
Add `export const fetchCache = 'force-no-store'` — the lever that forces every fetch in a segment to `no-store` regardless of its options — to:
- the `/admin` layout (cascades to all admin pages → "ensure no admin caching")
- the owner-only live API routes not under `/admin`: `api/mcp/tokens`, `api/files`, `api/media`, `api/media/unused`, `api/posts/[slug]/revisions`, `api/backup`

Public pages set neither config, so they **keep** their cached/ISR reads (verified: `/[slug]` still SSG + 1h). Also corrected the wrong assumption in `db.ts`, the route comments, and the CLAUDE.md gotcha.

## Verify
- `npm run lint` + `npm run build` exit 0
- Build route table: `/admin/*` and the touched API routes are Dynamic (ƒ); `/[slug]` stays SSG + 1h revalidate
- Confirmed in DB the OAuth tokens already exist and are used — this was purely a stale admin read

🤖 Generated with [Claude Code](https://claude.com/claude-code)