### PR TITLE
chore: one-command verification (check:all) + seam tests + debug-first docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,8 +1,9 @@
 # Architecture
 
 A fresh-reader map of vibeblog: the mental model, how a request flows, and the
-*why* behind the main decisions. Operational detail, traps, and recovery all live
-in [`CLAUDE.md`](./CLAUDE.md).
+*why* behind the main decisions. Operational rules, invariants, and a per-area DEBUG
+ROUTER live in [`CLAUDE.md`](./CLAUDE.md); per-area detail lives in [`docs/`](./docs/)
+(conventions, features, seo-pwa, mcp, backups).
 
 ## Mental model
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+## 2026-06-23 (v1.0.18 — verification is one command now, not a reading session)
+- **build: `npm run check:all` is the Definition of Done** — typecheck + lint + four static
+  invariant checks (`check:routes`, `check:filesize`, `check:no-any`, `check:token-bust`) + the
+  vitest suite, all offline/no-creds. Codifies the manual greps that lived in `CHECKLIST.md` /
+  `audit/README.md`. A separate `check:consistency:live` cross-checks the `media`/`files` rows
+  against the real Blob store (skips cleanly without `.env.local`).
+- **test: a minimal vitest seam suite (62 tests, <0.5s)** pinning the load-bearing invariants —
+  blob collapse/expand round-trip, shared slug namespace, revalidate SUPERSET, markdown raw-HTML
+  escaping + ToC anchor sync, and soft-delete (trashed content never leaks to a live read). Not
+  broad coverage by design.
+- **refactor: split two oversized modules under the 400-line cap (behaviour-preserving)** —
+  `lib/media.ts` → `lib/image.ts` (pure sharp encoding) and `lib/settings.ts` →
+  `lib/settings-sanitize.ts` (pure validation/migration); both one-way imports, all re-exports kept.
+- **docs: CLAUDE.md restructured for debugging (504 → 199 lines)** — a per-area DEBUG ROUTER + a
+  numbered Invariants list (each with its enforcing test/guard) up front; topic detail moved to
+  `docs/{conventions,features,seo-pwa,mcp,backups}.md`, loaded on demand. No runtime change. `v1.0.18`.
+
 ## 2026-06-23 (v1.0.17 — admin live reads were silently served from the 1h Data Cache)
 - **fix(admin): the MCP token list (and every admin live read) could show STALE data —
   most visibly "list token không hiện" after connecting a connector from Claude.** Root cause:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,10 @@ credentials live only in the gitignored `.env.local` and on Vercel (`vercel env
 pull`); never commit them. Personal/instance facts are not tracked in git.
 
 > **Companion doc — don't duplicate it here.** [`ARCHITECTURE.md`](./ARCHITECTURE.md) =
-> the mental model + the *why* behind decisions. This file = operational rules,
-> gotchas/traps, and the per-area map. When they'd overlap, the *why* lives there, the
-> *rule* lives here. The DB schema is [`scripts/schema.sql`](./scripts/schema.sql).
+> the mental model + the *why* behind decisions. This file = operational rules, invariants,
+> and a per-area DEBUG ROUTER. When they'd overlap, the *why* lives there, the *rule* lives
+> here. DB schema = [`scripts/schema.sql`](./scripts/schema.sql). Per-area detail lives in
+> [`docs/`](./docs/) — the DEBUG ROUTER points you at the right file; don't preload them all.
 
 ## Working principles
 
@@ -33,17 +34,18 @@ simplify. (This is also why the `lib/` data layer is thin and routes are thin ha
 existing style even if you'd do it differently. Remove imports/vars/functions that YOUR
 change orphaned; do NOT delete pre-existing dead code unless asked — mention it. Every
 changed line traces to the request. **Mandatory exception:** when you change behavior,
-update the matching docs in the SAME change (see "Docs & releases") — that's part of the
+update the matching docs in the SAME change (see "Conventions") — that's part of the
 request, not scope creep.
 
-**4. Goal-driven execution — define success criteria, then loop until verified.** Recast a
-task as something checkable ("add validation" → "invalid inputs are rejected, each path
-exercised"; "fix the bug" → "I can reproduce it, then it's gone"). For multi-step work,
-state a brief plan with a verify step each. **There is NO automated test suite here** —
-verification = `npm run build` AND `npm run lint` both exit 0 (strict `tsc`, no `any`) +
-reasoning through / manually exercising the real behavior (a route, a render, a PageSpeed
-run), and the `audit/` procedure for a release/feature batch. "It compiles" is necessary,
-not sufficient — confirm behavior, and report failures honestly with their output.
+**4. Goal-driven execution — define success criteria, then loop until verified.** Recast a task
+as something checkable ("fix the bug" → "I reproduce it, then it's gone"); state a brief plan with
+a verify step. **Definition of Done — a change is DONE only when `npm run check:all` exits 0**
+(typecheck + lint + `check:routes`/`check:filesize`/`check:no-any` + the `npm test` seam net;
+offline, no creds). No "it compiles" exception; if a change touches behaviour not in `check:all`,
+add a test for it IN THE SAME commit. Seams pin load-bearing invariants only (see Invariants), NOT
+broad coverage; a release batch also runs `npm run build` + the `audit/` procedure + manual checks
+a script can't. **Suspect data drift (media/blob mismatch)? Run `npm run check:consistency:live`
+BEFORE reading code** (live, needs `.env.local`; skips cleanly without creds). Report failures honestly.
 
 ## Architecture (operational)
 
@@ -52,460 +54,146 @@ not sufficient — confirm behavior, and report failures honestly with their out
   `backup_state` `activity_log` `analytics_events` `analytics_scroll` — full DDL in
   `scripts/schema.sql`; data-model shapes + the *why* in ARCHITECTURE.md.
   `backup_state` (single row) holds the **secret** Drive refresh token + run state and
-  is NEVER read into the client-bound settings payload (see Backups).
-- Writes are atomic upserts/deletes (no read-modify-write manifest); reads always fresh +
-  transactional.
+  is NEVER read into the client-bound settings payload (see `docs/backups.md`).
 - `src/lib` = data layer (`db.ts` Postgres, `blob.ts` binaries); `src/app/api` = thin
-  owner-gated handlers; UI in `src/components`.
+  owner-gated handlers; UI in `src/components`. Writes are atomic upserts/deletes (no
+  read-modify-write manifest); reads always fresh + transactional.
+- **Data flow:** public read = server component → `src/lib` (`getPost`/`getSettings`/…) →
+  `marked` render (ISR-cached). Write = `src/app/api/*` route → `requireOwner()` → `src/lib`
+  mutate Postgres/Blob → `src/lib/revalidate.ts` purge.
 - **Env:** `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` (secret, server-only) + the Blob
-  token — `.env.local` + Vercel only. The MCP server is enabled + tokenized from the admin (no
-  `MCP_TOKEN` env); optional `MCP_OAUTH_SECRET` signs OAuth codes (falls back to `AUTH_SECRET`).
+  token — `.env.local` + Vercel only. MCP enabled + tokenized from the admin (no `MCP_TOKEN`
+  env); optional `MCP_OAUTH_SECRET` signs OAuth codes (falls back to `AUTH_SECRET`).
+- **Region:** `vercel.json` pins functions + the Blob store to `sin1` (Singapore); OG is edge.
+  Detail → `docs/seo-pwa.md`.
 
-## Blob — `src/lib/blob.ts` (BINARIES ONLY)
+## Invariants — load-bearing, do not break
 
-Exports: `blobUrl`, `uploadFile`, `deleteByUrl`, `deleteByPathname`, `listBlobs`,
-`blobOrigin`, `collapseBlob`, `expandBlob`. (Text I/O moved to Postgres — there is no
-`readJson/readText/writeText` or `?ts` cache-bust anymore.)
+Each is *Enforced at* code + pinned by a *Test* or static *Guard* — all run by `npm run check:all`.
 
-- **Never call `list()`/`resolveUrl` to find a URL.** URLs are deterministic:
-  `blobUrl(pathname)` builds them from the token (`vercel_blob_rw_<storeId>_<secret>` →
-  `https://<storeId>.public.blob.vercel-storage.com/<pathname>`).
-- **Stored content is store-relative.** `collapseBlob` strips the host → pathname on WRITE;
-  `expandBlob` re-adds the current store base on READ. Applied in the data layer only
-  (posts/pages/settings), so UI keeps absolute URLs while stored bytes carry no storeId.
-  Both idempotent; external URLs untouched; old absolute content still renders and
-  self-heals on next save. (Migration rationale → ARCHITECTURE.md.)
-- **No vanity media domain** (removed v0.9.13): public media serves straight from the Blob
-  store host; there is NO `mediaBaseUrl` setting or `BLOB_PUBLIC_BASE` env.
+1. **Revalidate is a SUPERSET — never under-purge.** Every admin write goes through ONE place,
+   `lib/revalidate.ts`; each helper runs `freshenData()` (`revalidateTag('db')`) THEN a
+   `revalidatePath` superset of what the change touches. *Enforced at:* `lib/revalidate.ts`.
+   *Test:* `lib/revalidate.test.ts`.
+2. **Posts + pages share ONE `/{slug}` namespace.** Every create/rename calls `ensureSlugFree`
+   → 409 `SlugConflictError` on collision (trashed rows still reserve their slug).
+   *Enforced at:* `lib/slugs.ts`. *Test:* `lib/slugs.test.ts`.
+3. **Image refs are stored store-relative.** `collapseBlob` strips the host on WRITE, `expandBlob`
+   re-adds it on READ — applied in the data layer only (posts/pages/settings), so stored bytes
+   carry no storeId. *Enforced at:* `lib/blob.ts` + the data-layer files. *Test:* `lib/blob.test.ts`.
+4. **Every write/delete route calls `requireOwner()` first.** `src/middleware.ts` is the edge
+   defence-in-depth net (blocks `/admin` + owner-only `/api`); a NEW public/bearer route must be
+   added to `isPublicApi()` or it 401s. *Enforced at:* `lib/api.ts` + `src/middleware.ts`.
+   *Guard:* `check:routes` (static presence) + the middleware net; no integration test.
+5. **Raw HTML in markdown is escaped, never executed.** `html` renderer → `escapeHtml`; `safeHref` drops
+   `javascript:`/`data:`/`vbscript:`. *Enforced at:* `PostContent.tsx`. *Test:* `post-content.test.ts`.
+6. **Every delete is a soft delete.** `deleteX()` sets `deleted_at`; EVERY live read filters
+   `.is('deleted_at', null)` (each read writes its own WHERE — no shared helper; guarantee by repetition).
+   *Enforced at:* data-layer files + `docs/features.md`. *Test:* `lib/soft-delete.test.ts` (4 read paths).
+7. **Cache-bust is asymmetric.** Out-of-band writes (`backup_state`) MUST `revalidateTag(DB_TAG)`; MCP
+   token routes MUST NOT (`force-no-store`; busting `db` over-purges public). *Enforced at:*
+   `lib/backup-state.ts` vs `api/mcp/tokens`. *Test:* `check:token-bust` (backup side = coarse tripwire).
 
-## Region (latency)
+> **Accepted risk — no drift check (2C):** `scripts/schema.sql` is hand-maintained, the app never runs
+> it. Any table/RPC/index change MUST update it in the SAME commit — review-enforced (live diff declined).
 
-`vercel.json` pins functions to **`sin1` (Singapore)**; the Blob store is in Singapore
-too (co-located reads, no cross-region hop). The OG route is `runtime = 'edge'`. (Self-host:
-change/remove `regions` for your audience — see README.)
+## DEBUG ROUTER — when you hit a symptom, read THESE files first
 
-## Caching — ISR pages + tagged DB reads, purge on save — READ THIS
-
-Two coordinated layers, both invalidated on every write so an edit is never stale:
-
-- **Page** (Full Route Cache / ISR): public pages export `revalidate = 3600`; `/[slug]`
-  also has `generateStaticParams` → prerendered.
-- **Supabase reads** (Data Cache): `db.ts` makes GET reads cache-eligible
-  (`next: { revalidate: 3600, tags: ['db'] }`) so a page that reads them stays static/ISR.
-  Writes are `no-store`.
-
-**Every admin write goes through ONE place — `src/lib/revalidate.ts`** — and each helper
-begins with `freshenData()` = `revalidateTag('db')` (next render reads CURRENT Postgres)
-THEN a `revalidatePath` SUPERSET (which pages re-render):
-- `revalidateNewPost()` — all list/taxonomy surfaces (home, `/page/[n]`,
-  `/category|tag/[slug]`(+`/page/[n]`), `feed.xml`, `sitemap.xml`, `llms.txt`).
-- `revalidatePost(slug, prevSlug?)` — its own page (old+new slug) + the list surfaces.
-- `revalidatePage(slug, prevSlug?)` — its own URL(s) + `sitemap.xml`/`llms.txt`.
-- `revalidateEverything()` — settings / taxonomy / media-delete / "Clear all cache"
-  (settings + Clear also `warmCache()`). Media *upload* alone purges nothing.
-
-Other rules:
-- Admin forms `router.refresh()` after save; admin routes are `force-dynamic` (their DB
-  reads become `no-store` → editor/media/settings always live).
-- **GOTCHA — admin LIVE reads need `fetchCache = 'force-no-store'`, NOT just
-  `dynamic = 'force-dynamic'`.** Our `db()` GET reads opt into the Data Cache with an
-  explicit `next: { revalidate, tags:['db'] }`. `force-dynamic` does NOT de-cache those —
-  Next only auto-de-caches force-dynamic fetches that set NO revalidate (the
-  `noFetchConfigAndForceDynamic` path in `patch-fetch.js`); an explicit `revalidate`
-  survives. So a tagged read stays in the 1h Data Cache and shows STALE rows after a
-  mutation — especially OUT-OF-BAND ones that don't purge tag `db` (MCP/OAuth token
-  mints from Claude, cron backup state). `fetchCache = 'force-no-store'` is the lever that
-  forces EVERY fetch in the segment to `no-store` regardless of its options. Set BOTH on:
-  the `/admin` layout (cascades to all admin pages) and the owner-only list API routes
-  (NOT under `/admin`): `api/mcp/tokens`, `api/files`, `api/media`, `api/media/unused`,
-  `api/posts/[slug]/revisions`, `api/backup`. Token CRUD intentionally does NOT
-  `revalidateTag('db')` (that would over-purge public pages) — `force-no-store` gives a
-  live admin read with zero public-cache impact. (This caused "list token không hiện"
-  after an OAuth connect, and earlier the "backup shows not-connected" bug 1.0.11–1.0.13.)
-- `experimental.staleTimes: { dynamic: 0, static: 30 }` (Next 16 rejects `static: 0`).
-- **Accepted staleness:** the "related posts" box on OTHER posts (≤1h ISR / next save).
-- **DO NOT** set the Supabase GET reads to `cache: 'no-store'` (forces every page dynamic,
-  kills ISR), and **do not** enable `cacheComponents: true`. Keep every write going through
-  `revalidate.ts`.
-
-## Rendering — `src/app/(blog)/[slug]/page.tsx`
-
-- `revalidate = 3600` + `generateStaticParams` (all slugs) + `dynamicParams`. Reads
-  `getPost` + `getPage` (shared `/{slug}` namespace) + `getMedia` (the `<picture>` set).
-- Admin `/admin/*` is `force-dynamic`; search/preview/og are dynamic.
-- **Pagination is path-based:** page 1 at the bare path, deeper at `/page/[n]`
-  (+`/category|tag/[slug]/page/[n]`) — no `?query`. `parsePathPage` returns a page only for
-  `n >= 2` (else `null` → 404). Shared `components/blog/BlogListing` renders all six routes.
-- **Taxonomy URLs use the SLUGIFIED term** (`lib/taxonomy.ts`): `Suy nghĩ` → `/category/suy-nghi`,
-  NOT the raw `%`-encoded name. Links call `termSlug(term)` (post footer, sitemap); the four
-  `category|tag/[slug]` routes call `resolveTerm(posts, kind, slug)` → the term whose `slugify`
-  matches (+ a back-compat match on the raw pre-slug term, so old encoded URLs still resolve) →
-  `notFound()` if none. New taxonomy link/route MUST go through these (never hand-encode the name).
-- List entries carry `readingMinutes` (computed at save) so lists need no bodies.
+| Symptom / area | Read these first | Read more if needed |
+|---|---|---|
+| Image: upload / variant / responsive | `lib/media.ts`, `lib/blob.ts`, `lib/upload-client.ts`, `api/media/*`, `components/blog/PostContent.tsx` | `lib/media-usage.ts` |
+| Cache / stale / content not updating / ISR | `lib/revalidate.ts`, `lib/db.ts`, `lib/posts.ts` | ARCHITECTURE "Request flow" |
+| Auth / route 401 / route exposed | `lib/auth.ts`, `lib/api.ts`, `src/middleware.ts`, `api/<route>/route.ts` | `docs/mcp.md` if MCP |
+| Slug / 404 / duplicate URL | `lib/slugs.ts`, `src/app/(blog)/[slug]` | `lib/posts.ts`, `lib/pages.ts` |
+| Trash / soft delete / restore | `lib/posts.ts` (`deleted_at`), `api/trash`, `src/app/admin/trash` | `docs/features.md` |
+| Backup / restore / cron | `docs/backups.md`, `lib/backup.ts`, `lib/gdrive.ts`, `lib/backup-state.ts` | — |
+| Theme / palette / dark / FOUC | `lib/themes.ts`, `src/components/theme/*` | `docs/conventions.md` |
+| Typography / font / layout drift | `docs/conventions.md` FIRST, then the component | — |
+| Search / ToC / related / preview | `lib/posts.ts`, `api/search`, `components/blog/PostContent.tsx` | `docs/features.md` |
+| SEO / sitemap / feed / robots / OG | `docs/seo-pwa.md`, `src/app/{robots,sitemap,llms.txt,feed.xml,og}` | `lib/og.ts` |
+| PWA / manifest / favicon | `docs/seo-pwa.md`, `src/app/manifest.ts`, `src/app/layout.tsx` | — |
+| MCP server | `docs/mcp.md`, `src/lib/mcp/*`, `src/app/api/mcp/*` | — |
 
 ## Data layer map — `src/lib/`
 
-Terse role per file; the authoritative detail is the code comments. Gotchas that are rules
-are called out elsewhere (Caching, Typography, Conventions).
+Terse role per file; the authoritative detail is the code comments.
 
 | File | Key exports | Role |
 |---|---|---|
 | `db.ts` | `db()` | Server-only `service_role` client; GET reads cache-eligible + tagged `db`, writes `no-store`. ALL text access goes through here |
-| `blob.ts` | (see Blob above) | Binaries only; deterministic URLs, never `list()` to read |
-| `posts.ts` | `getIndex`, `getPublicPosts`, `getPost`, `savePost`, `deletePost`, `getCategories`, `getTags`, `updateTerm` | Reads `React.cache()` only. `savePost` snapshots the prior version (`revisions.ts`) + stores `readingMinutes`. `updateTerm` renames (merges on collision) / removes a term across EVERY post |
+| `blob.ts` | `blobUrl`, `uploadFile`, `deleteByUrl/Pathname`, `listBlobs`, `blobOrigin`, `collapseBlob`, `expandBlob` | Binaries only; deterministic URLs (never `list()` to read); `collapse/expand` = store-relative refs |
+| `posts.ts` | `getIndex`, `getPublicPosts`, `getPost`, `savePost`, `deletePost`, `getCategories`, `getTags`, `updateTerm` | Reads `React.cache()` only. `savePost` snapshots prior version + stores `readingMinutes`. `updateTerm` renames (merges on collision) / removes a term across EVERY post |
 | `pages.ts` | `getPageIndex`, `getPublicPages`, `getPage`, `savePage`, `deletePage` | Mirrors `posts.ts` |
 | `revisions.ts` | `getRevisions`, `pushRevision`, `renameRevisions`, `deleteRevisions` | Last 3 overwritten versions/slug (`post_revisions` jsonb, store-relative). Re-slugged on rename, removed on delete |
-| `media.ts` | `getMedia`, `addMedia*`, `registerMediaBatch`, `deleteMedia*`, `finalizeContentMedia`, `finalizePendingVariants`, `finalizePendingThumbs` | Metadata in `media`, binaries on Blob. **Browser→Blob direct upload** (`/api/media/blob-token`) then `register` (reads dims, makes `-thumb.webp`) — dodges the 4.5MB function-body limit. Keeps untouched ORIGINAL + thumb; heavy `-1024`/`-1600` AVIF+WebP **deferred** (`finalizeContentMedia` via `after()`, cron-swept). Delete removes EVERY version. `PostContent` emits `<picture>` only when variants exist; body `<img>` carry intrinsic `width`/`height` (CLS-free), first eager + `fetchpriority=high` (LCP), rest lazy |
-| `files.ts` | `renderLogo`, `uploadIcon`, `uploadFont`, `getFiles`, `addFilesBatch`, `deleteFile`, `deleteFilesBatch`, `getSiteIcons` | The `files/` prefix holds 3 NON-grid things: custom font (`font-<weight>-<ms>`), site icons (`favicon-`/`app-icon-`, accept `.ico`), and the Files attachment library (table rows). `renderLogo` → see Header. `deleteFile*` refuse `favicon-`/`app-icon-` |
-| `settings.ts` | `getSettings`, `saveSettings`, `DEFAULT_SETTINGS`, `resolveAppIcon`, `typographyToCss`, `fontToCss` | `getSettings` `React.cache()` only. Holds the `themes` map + `typography` + `customFont`; migrates legacy shapes; image/font urls store-relative at rest. `resolveAppIcon` = appIcon → favicon → `/app-icon.png` |
-| `themes.ts` | `THEME_PRESETS`, `themesToCss`, `paletteOptions`, … | 6 owner-customizable palettes (Mono/Sepia/Forest/Ocean/Rose/Amber). `themesToCss` emits EVERY palette's vars. Add one = append to `THEME_PRESETS` (names not localized) |
-| `analytics.ts` | `recordView`, `recordScroll`, `getAnalytics`, `getViewTotals`, `isBot` | Cookieless (`analytics_events` + `analytics_scroll`). `visitor` = salted (`AUTH_SECRET`) hash of IP+UA — **no PII**; bots + admin/api + the **owner's own** visits skipped. `getAnalytics` → `analytics_summary` RPC; `getViewTotals` → `analytics_totals`. Kept FOREVER. Beacons `Track.tsx` (every page) + `ScrollDepth.tsx` (posts) fire after hydration (pages stay SSG) |
+| `media.ts` | `getMedia`, `addMedia*`, `registerMediaBatch`, `deleteMedia*`, `finalizeContentMedia`, `finalizePendingVariants/Thumbs` | Metadata in `media`, binaries on Blob. Browser→Blob direct upload then `register` (reads dims, makes `-thumb.webp`). Heavy `-1024/-1600` AVIF+WebP deferred via `after()`, cron-swept. Delete removes EVERY version. `PostContent` emits `<picture>` only when variants exist |
+| `files.ts` | `renderLogo`, `uploadIcon`, `uploadFont`, `getFiles`, `addFilesBatch`, `deleteFile*`, `getSiteIcons` | `files/` prefix = custom font, site icons (`favicon-`/`app-icon-`), attachment library. `deleteFile*` refuse `favicon-`/`app-icon-` |
+| `settings.ts` | `getSettings`, `saveSettings`, `DEFAULT_SETTINGS`, `resolveAppIcon`, `typographyToCss`, `fontToCss` | `React.cache()` only. Holds `themes` + `typography` + `customFont`; migrates legacy shapes; image/font urls store-relative |
+| `themes.ts` | `THEME_PRESETS`, `themesToCss`, `paletteOptions`, … | 6 owner-customizable palettes. `themesToCss` emits EVERY palette's vars. Add one = append to `THEME_PRESETS` |
+| `analytics.ts` | `recordView`, `recordScroll`, `getAnalytics`, `getViewTotals`, `isBot` | Cookieless; `visitor` = salted hash of IP+UA (no PII); bots + admin/api + owner skipped. Kept FOREVER |
 | `activity.ts` | `logActivity`, `getActivity`, `clearActivity` | `activity_log`; gated by `features.activityLog`, never throws; called via `after()` from every mutating route |
-| `media-usage.ts` | `findUnusedMedia` | Read-only audit (scans posts/pages/settings + revision snapshots); badges orphans, never deletes |
-| `backup.ts` | `runBackup`, `maybeRunBackup`, `listBackups`, `deleteBackup`, `restoreBackup` | Full-snapshot backup to Google Drive (one `.tar.gz` = `db.json` + all blobs + manifest). `maybeRunBackup` = the cron entry (due check). `restoreBackup` is DESTRUCTIVE (replaces tables + re-uploads blobs; pre-restore snapshot taken first; strips `id`/`search`) |
-| `backup-state.ts` | `getBackupState`, `toStatus`, `setDriveAuth`, `clearDriveAuth`, `recordRun` | SERVER-ONLY secret store (`backup_state`): Drive refresh token + folder id + last-run. `toStatus` is the client-safe view (NO token) |
-| `gdrive.ts` | `consentUrl`, `exchangeCode`, `accessToken`, `signState`/`verifyState`, `ensureFolder`, `listSnapshots`, `uploadSnapshot`, `deleteSnapshot`, `downloadSnapshot` | Drive REST + the separate `drive.file` OAuth flow (reuses the Google client; login scope untouched) |
-| `highlight.ts` | `highlightCode` | Server-side Shiki (Vitesse dual-theme); zero client JS; null on failure → caller keeps the plain block |
-| `auth.ts` | `handlers`, `auth`, `signIn`, `signOut`, `isAuthorized`, `getAuthState` | Anyone signs in; only `AUTHORIZED_EMAIL` is authorized |
+| `media-usage.ts` | `findUnusedMedia` | Read-only audit; badges orphans, never deletes |
+| `backup.ts` / `backup-state.ts` / `gdrive.ts` | (see `docs/backups.md`) | Drive snapshot/restore + the server-only secret store + Drive REST/OAuth |
+| `highlight.ts` | `highlightCode` | Server-side Shiki; zero client JS; null on failure → plain block |
+| `auth.ts` | `handlers`, `auth`, `signIn/Out`, `isAuthorized`, `getAuthState` | Anyone signs in; only `AUTHORIZED_EMAIL` is authorized |
 | `slugs.ts` | `ensureSlugFree`, `SlugConflictError` | Posts + pages share the namespace → 409 on collision |
 | `revalidate.ts` | `revalidateNewPost/Post/Page/Everything`, `warmCache` | Single source of cache invalidation (see Caching) |
 | `api.ts` | `ok`, `fail`, `logRequest`, `logError`, `requireOwner` | Every route calls `requireOwner()` first |
-| `taxonomy.ts` | `termSlug`, `resolveTerm` | Category/tag URL slug (`slugify(term)`) + reverse-resolve a slug to its display name + matching posts (back-compat with raw pre-slug URLs) |
-| others | `video.ts` (YT/Vimeo/TikTok embeds), `paginate.ts`, `i18n.ts` (`t`/`formatDate`), `admin-i18n.ts`, `utils.ts` (`slugify`/`deriveExcerpt`/`isPublicallyVisible` = published && date past /…) | Pure/shared helpers |
+| `taxonomy.ts` | `termSlug`, `resolveTerm` | Category/tag URL slug + reverse-resolve a slug to its display name (back-compat with raw pre-slug URLs) |
+| others | `video.ts`, `paginate.ts`, `i18n.ts`, `admin-i18n.ts`, `og.ts`, `preview.ts`, `upload-client.ts`, `utils.ts` (`slugify`/`deriveExcerpt`/`isPublicallyVisible`) | Pure/shared helpers |
 
-## Trash (soft delete) — Admin → Trash (`/admin/trash`)
+## Caching — ISR pages + tagged DB reads, purge on save
 
-- **Every delete is a soft delete.** `posts`/`pages`/`media`/`files` each have a nullable
-  `deleted_at` (NULL = live, timestamp = trashed). `deleteX()` sets `deleted_at`; nothing is
-  hard-deleted on a normal delete. EVERY live read filters `.is('deleted_at', null)`
-  (index/search/getPost, page index/getPage, media/file lists, the finalize sweeps) so trashed
-  items leave the site, lists, search, sitemap/feed/llms and the libraries at once.
-- **Media/file soft delete KEEPS the blob** — a published post linking a trashed image keeps
-  rendering; the blob is removed only on purge. So `/api/media/delete` no longer purges the page
-  cache (it used to). A trashed row **keeps its slug** (still reserved via `ensureSlugFree`) so
-  restore never collides.
-- Per kind the lib exports `restoreX`, `purgeX` (hard delete: row + revisions/blobs),
-  `getTrashedX`, `emptyXTrash`. The Trash page server-loads all four lists; `TrashView` (4 tabs)
-  acts via **`POST /api/trash`** `{ kind, action: restore|purge|empty, ids? }` (owner-gated) then
-  `router.refresh()`. **Nothing auto-purges** — permanent removal is manual (per-item or Empty
-  trash). Restores revalidate the item's surfaces; media/file purges `revalidateEverything()`.
-- Adding a mutating trash action → log it (activity actions `*.restore` / `*.purge` /
-  `trash.empty`) and keep the i18n keys in sync.
+Two coordinated layers, both invalidated on every write so an edit is never stale. **Full
+mechanism + the *why* (and the old no-DB bug it replaced) → ARCHITECTURE.md "Request flow".**
 
-## MCP server — `/api/mcp` + `src/lib/mcp/`
+- Public pages export `revalidate = 3600`; `/[slug]` also has `generateStaticParams` (prerendered).
+  `db.ts` GET reads are cache-eligible + tagged `db`; writes are `no-store`. Pagination is
+  path-based (`/page/[n]`, `/category|tag/[slug]/page/[n]`; page 1 at the bare path).
+- Every admin write goes through `lib/revalidate.ts` (Invariant 1) — `freshenData()` then a `revalidatePath` superset; `Everything` (settings/taxonomy/media-delete/Clear) also `warmCache()`.
+- **GOTCHA — admin LIVE reads need `fetchCache = 'force-no-store'`, NOT just `dynamic =
+  'force-dynamic'`.** `db()` GET reads set an explicit `next:{revalidate,tags:['db']}` which
+  `force-dynamic` does NOT de-cache — so a tagged read stays in the 1h Data Cache and shows STALE
+  rows after an OUT-OF-BAND mutation that doesn't purge tag `db` (MCP/OAuth token mints, cron backup
+  state). Set `fetchCache = 'force-no-store'` on the `/admin` layout AND the owner-only list API
+  routes not under `/admin` (`api/mcp/tokens`, `api/files`, `api/media`, `api/media/unused`,
+  `api/posts/[slug]/revisions`, `api/backup`). (Caused "token list missing" + the 1.0.11–1.0.13 bug.)
+- **DO NOT** set Supabase GET reads to `no-store` (kills ISR) or enable `cacheComponents: true`; keep every write going through `revalidate.ts`.
 
-- **What it is.** A remote MCP endpoint (Streamable HTTP, `mcp-handler` + `@modelcontextprotocol/sdk`)
-  that lets an MCP client (Claude/ChatGPT) operate the blog. Tools are THIN wrappers over the same
-  `lib/` functions the admin routes use — same slug rules, revisions, soft-delete, revalidation,
-  activity log. **Off unless the owner enables it** (Admin → Settings → Advanced toggle,
-  `settings.mcp.enabled`); `verifyMcpToken` 401s every call while off.
-- **Auth = admin-managed tokens + thin OAuth.** Manual tokens are created in the admin (up to 5,
-  named, shown ONCE on creation — only the SHA-256 hash is kept in the `mcp_tokens` table; see
-  `lib/mcp/tokens.ts`). Every token **expires 180 days after creation** (`expires_at`, set on insert,
-  default in `schema.sql`); `verifyMcpToken` hashes the bearer, looks it up, **rejects it once past
-  `expires_at`**, else stamps `last_used_at` (while the toggle is on). There is **no `MCP_TOKEN` env
-  var.** Connectors that require OAuth run a minimal OAuth 2.1 authorization-code + PKCE flow gated by
-  the owner's NextAuth login (`src/app/api/mcp/{authorize,token,register}` + `src/app/.well-known/oauth-*`);
-  the `/token` exchange **mints a 180-day token via `mintOAuthToken`** (named "OAuth connector") and
-  returns it. **OAuth tokens are exempt from the manual 5-cap and are NEVER auto-deleted** (an expired
-  row lingers as dead until the owner deletes it; a connector silently re-authorizes to mint a fresh one).
-  **Lifecycle rule: the admin is the SOLE authority over a connection** — beyond the 180-day expiry a
-  token persists (no prune) until the OWNER deletes it in the admin; deleting the connector in Claude
-  alone just lets it re-authorize (a new token). So authorize once = stays connected (connector
-  re-auths across the 180-day boundary), and an admin delete is final unless the owner re-authorizes.
-  (A reconnect mints a new row; the prior one persists until the owner removes it — the admin
-  lists/deletes them all.) Codes are HMAC-signed
-  (`MCP_OAUTH_SECRET` → falls back to `AUTH_SECRET`) in `lib/mcp/auth.ts`. Token CRUD: owner-only
-  `/api/mcp/tokens` (+ `/[id]`); UI in `components/admin/McpFields.tsx` (cap counts manual only).
-- **Tools** (`lib/mcp/tools.ts` posts/pages/taxonomy, `tools-library.ts` media/files/settings;
-  results via `result.ts`). Content is Markdown verbatim — no HTML conversion. Deletes are soft
-  (→ Trash). **`update_settings` exposes only a safe allowlist (title/description/showDescription)** —
-  the zod inputSchema IS the allowlist, so sensitive settings can't be written over MCP. `get_settings`
-  reads all. **Adding a tool that mutates → revalidate + `logActivity` like the admin routes.**
+## Rendering — `src/app/(blog)/[slug]/page.tsx`
 
-## Backups — Google Drive (Admin → Settings → Advanced)
-
-- **What it is.** A full-site snapshot to the owner's Google Drive: one self-contained
-  `.tar.gz` = `db.json` (every text table except `backup_state`) + `blob/<pathname>` (every
-  binary) + `manifest.json`. Built in `/tmp` then resumable-uploaded into a `vibeblog-backups`
-  Drive folder. Runs on a schedule (cron, every `settings.backups.intervalDays`, default 4) or
-  the "Back up now" button; retention keeps the newest `settings.backups.keep` (default 4).
-- **Auth is SEPARATE from sign-in.** A dedicated `drive.file` OAuth flow (reuses the Google
-  client `AUTH_GOOGLE_*`, never touches the login scope): `GET /api/backup/connect` → Google
-  consent → `GET /api/backup/callback` exchanges the code for a **refresh token**, stored in
-  `backup_state` (server-only). `drive.file` = the app only ever sees files IT created. The
-  **redirect URI is `backupRedirectUri(settings)` = `${resolveSiteUrl(settings)}/api/backup/callback`**
-  — derived from the canonical site URL, NOT `req.nextUrl.origin` (which is a `*.vercel.app` host
-  when the admin is opened there → `redirect_uri_mismatch`). So the URI registered on the OAuth
-  client must use the canonical host (`settings.siteUrl`).
-- **Secret hygiene (HARD RULE).** The Drive refresh token must NEVER reach the client. It lives
-  in `backup_state`, NOT in `settings.data` (which is sent to the admin). Only non-secret config
-  (`enabled`/`intervalDays`/`keep`) lives in `settings.backups` and flows through the settings
-  form; the connection + snapshot list come from owner-only `/api/backup` (returns `toStatus`,
-  never the token) — same split as MCP tokens.
-- **`backup_state` writes MUST `revalidateTag(DB_TAG, 'max')`** (`backup-state.ts`:
-  `setDriveAuth`/`clearDriveAuth`/`setFolderId`/`recordRun`). The state read is Data-Cache-eligible
-  (tag `db`, 1h) and is read by BOTH `/api/backup` and the admin Overview — `force-dynamic` on one
-  route is NOT enough to dodge the *shared* Data Cache, so without busting it the admin showed stale
-  "not connected" after a successful connect (the bug that shipped in 1.0.11–1.0.13).
-- **Restore is DESTRUCTIVE** (`POST /api/backup/restore`): replaces every text table (settings
-  upserted by id=1; others delete-all then insert with `id`/`search` stripped) and re-uploads
-  every blob. A **pre-restore snapshot is taken first**. UI confirms before calling.
-- **Routes:** `/api/backup` (GET status+list, POST run-now, DELETE `?id=`), `/api/backup/restore`,
-  `/api/backup/{connect,callback,disconnect}`. All owner-only (middleware + `requireOwner`); the
-  cron calls `maybeRunBackup()` directly (no HTTP). New mutating action? `logActivity('backup.*')`.
-- **Owner setup (one-time):** enable the **Google Drive API** in the Cloud project behind
-  `AUTH_GOOGLE_ID`, add `https://<domain>/api/backup/callback` (+ localhost) as an Authorized
-  redirect URI on the OAuth client, then click **Connect Google Drive**. No new env var.
-
-## Localization — `src/locales/` (RULES)
-
-- `types.ts` = shapes (`Dict` public, `AdminStrings` admin). Add a key → every locale file
-  must define it (`satisfies` → build error otherwise = the no-missing-keys guarantee).
-- `langs.ts` = `SITE_LANGS` + `isSiteLang`. Public `src/locales/<code>.ts`, admin
-  `src/locales/admin/<code>.ts`. Supported: **en (default), vi, de, ja, zh, ko** (CJK via
-  `system-ui` fallback — Inter has no CJK glyphs).
-- **Add a language:** extend `SiteLang`, add a `SITE_LANGS` row + a `DATE_LOCALE` entry in
-  `i18n.ts` + both locale files.
-- **Add/rename a string:** add to `types.ts`, then fill ALL locale files. Build fails until
-  complete. **Keep every locale in sync on any UI string change.**
-
-## Scripts — `scripts/`
-
-`node --env-file=.env.local scripts/<name>.mjs [--dry]` — idempotent.
-
-- **`schema.sql`** — full Postgres schema (11 tables + indexes + `posts.search` tsvector +
-  RLS + the analytics RPCs). Run ONCE on a fresh Supabase project. NOT run by the app;
-  transcribed from the live schema — **keep it in sync when you change tables/RPCs.**
-- **`migrate-to-supabase.mjs`** — one-off P1.5 migration (Blob `_index.json`+`.md` →
-  Postgres). Already run; kept for recovery.
-- **`scripts/legacy/` — pre-Supabase one-offs, do NOT run against the live site** (they operate
-  on the retired Blob `_index.json`/`.md` model): `import-wordpress`, `convert-html-to-markdown`,
-  `fix-import-captions`, `backfill-excerpts`, `rehost-images`, `rebuild-index`, `wipe-media`,
-  `backfill-reading-time`, `list-posts-with-images`, `check-image-links`,
-  `backfill-media-dimensions`, `remap-original-images`. Kept for recovery only; their deps
-  (`gray-matter`/`turndown`/`turndown-plugin-gfm`/`fast-xml-parser`) are devDependencies.
-
-## SEO (toggleable, Admin → Settings → SEO)
-
-- `settings.seo` = `{ autoSchema, sitemap, llms, robots, rss, ogImage, ogFallbackImage }` +
-  `settings.siteUrl` (canonical; '' → `VERCEL_PROJECT_PRODUCTION_URL` → localhost via
-  `resolveSiteUrl()`). Drives `metadataBase`.
-- `robots.ts` — always disallows `/admin`+`/api`; when on, a 3-group policy: search +
-  reputable AI bots allowed (`SEARCH_BOTS`/`AI_BOTS`, paired with `/llms.txt`), scrapers
-  (`BAD_BOTS`: Ahrefs/Semrush/…) `Disallow: /`, `*` welcoming. Lists are consts atop the file.
-- `sitemap.ts` — home + posts + pages + categories + tags; each post lists its images
-  (`<image:image>`). `sitemaps.xml` → 308 to `/sitemap.xml`.
-- `llms.txt` (markdown content index, 404 off) · `feed.xml` (RSS 50, 404 off, auto-discovered).
-- `og/route.tsx` — dynamic OG (1200×630, **edge**, Inter `.woff` subsets bundled); query
-  `title`/`site`/`bg` + optional `?font=<blobUrl>` (Blob host only, SSRF-guarded). `lib/og.ts`
-  builds the card URLs (`ogImageUrl` posts/pages, `ogCardUrl`+`siteDomain` lists); honors
-  `seo.ogImage`; appends `font=` when a custom font is set.
-- JSON-LD via `JsonLd.tsx` (`websiteSchema` home, `articleSchema` posts), gated `seo.autoSchema`.
-- robots/sitemap/feed/llms are ISR; an SEO toggle is a settings save → `revalidateEverything()`;
-  post create/edit purges feed/sitemap/llms.
-
-## Reading & discovery
-
-- Features `{ search, toc, related, readingTime, progressBar, activityLog }` (default on,
-  Admin → Settings → Tính năng); gated in header / `/search` / post page.
-- `/search` — **two layers:** a lean local index (`{slug,title,date,terms}`, instant +
-  accent-insensitive) merged with `GET /api/search?q=` (Postgres FTS over title + BODY via
-  `searchPosts` `.textSearch('search', …, {config:'simple'})`). **NOTE:** `simple` is accent-
-  *sensitive* — accent-insensitivity comes from the local layer only. Header search =
-  `SearchOverlay` (modal); the `/search` route stays for deep links / no-JS.
-- Post page: `ReadingProgress`, `BackToTop`, `Toc` (≥3 H2/H3; desktop-only, sticky in the
-  left gutter; `PostContent` assigns slug ids), `RelatedPosts` (`getRelatedPosts`: shared
-  tags ×2 + categories).
-- **GOTCHA:** the global unlayered `hr { margin:0 }` beats Tailwind margin utilities — put
-  divider spacing on a wrapper div, not on the `<hr>`.
-- **Heading ids are de-duped** (2nd `foo` → `foo-2`): `dedupeHeadingIds` (PostContent) and
-  `extractHeadings` (utils) run the SAME counter over H2/H3 in document order — change one, change
-  both or the ToC anchors break.
-- **Link hrefs are sanitized** (`safeHref` in PostContent drops `javascript:`/`data:`/`vbscript:`)
-  — marked v5+ no longer does. Raw HTML in markdown is already escaped (the `html` renderer →
-  `escapeHtml`), so `<script>`/`<img onerror>` render as visible text.
-- **Draft preview:** `/preview/[slug]?key=<hmac>` (force-dynamic, noindex);
-  `previewToken` = HMAC(slug, `AUTH_SECRET`); editor "Link nháp" button. Separate route keeps
-  `/[slug]` SSG + published-only.
-
-## Editor (Admin → editor) — `components/admin/Editor.tsx`
-
-- StarterKit + underline, inline code, bullet/numbered/**task** lists (GFM `- [ ]`), quote,
-  code block, hr, link, captioned image, GFM tables, video. `tiptap-markdown` serializes all.
-  **GOTCHA:** list items wrap content in `<p>`; `.prose li > p{margin:0}` keeps them tight.
-- Autosave every 60s while dirty (chained behind any in-flight save); warns on unload.
-- Time machine: each overwrite snapshots the prior version (`revisions.ts`, keeps 3); restore
-  loads it into the editor (non-destructive — current version is snapshotted on next save).
-
-## Content dashboard (Admin → content)
-
-- 3 tabs: Bài viết / Trang / Phân loại; "new" hidden on taxonomy.
-- `RowActions` (shared): open-in-new (PUBLISHED only) + edit + delete; exports the `ICON_BTN`
-  chrome for reuse. `StatusPill` never wraps.
-- Tables are mobile-responsive by **hiding secondary columns** (not horizontal scroll): posts
-  hide Date (`sm`) + Categories (`md`); pages hide slug (`sm`). Title + Status + actions always show.
-- `PostsTable` filter bar: substring search + All/Published/Draft (client-side).
-- `TaxonomyManager`: rename (merge) / remove terms across all posts → `updateTerm`.
-
-## Activity log + System panel (Admin)
-
-- **Activity log:** every mutating route does `after(() => logActivity(action, detail))`
-  (post/page CRUD, media/file/icon/font, settings, taxonomy, cache.clear, backup.*). Gated by
-  `features.activityLog`. Admin → Log (force-dynamic, latest 200, Clear). **Adding a mutating
-  route → log it too.**
-- **System panel** (admin Overview, `getSystemInfo()`): hosting/URL/region/env/git + database
-  (Supabase, live reachability) + Blob host + **MCP on/off** + **Backups on** (= enabled AND Drive
-  connected); rows may deep-link. The stat cards split media into **originals / variants / files**
-  (variants = blobs matching `-(thumb|NNNN).(avif|webp)`); category/tag cards show their total count.
-- **Analytics:** Admin → Analytics (24h/7d/30d/1y); a View column on the content tables
-  (`getViewTotals`). Detail in the data-layer map (`analytics.ts`).
-
-## Settings (Admin → settings) — `SettingsView.tsx`
-
-- **ONE form, ONE save button, THREE tabs** (`general | appearance | advanced`; tab state not
-  persisted). One `useState<SiteSettings>` → one PUT `/api/settings`.
-- Controlled field groups (no own state/save): General `SiteFields`/`LayoutMenuFields`/
-  `FeatureFields`/`SeoFields`; Appearance `ThemeFields`/`FontUpload`/`TypographyFields`/
-  `AdvancedFields` (font smoothing = "Text rendering"); Advanced `McpFields` + custom-CSS.
-  `McpFields` is the EXCEPTION to "no own state/save": the MCP enable toggle flows through the
-  settings form, but its token manager has its own `/api/mcp/tokens` API (plaintext shown once).
-- Each tab: `grid lg:grid-cols-2 items-start` (explicit columns, NOT CSS `columns`).
-- **Save calls `router.refresh()`** so the admin shell + public header reflect the change
-  immediately.
-
-## Header (public) — alignment is a HARD RULE
-
-- Logo + the icon row share ONE flex line (`items-center`) so icons stay on the logo's
-  vertical midline; the description sits below.
-- **The logo is auto-sized, never the raw original.** `settings.logoUrl` = the owner's
-  untouched source; the header renders `settings.logoRenderUrl` (small WebP scaled to
-  `logoWidth` @2x for retina, built on save by `renderLogo` in `files.ts`), falling back to
-  the original only for vector/animated logos. The `<img>` carries `width`+`height`
-  (`logoRenderHeight`) → no CLS. `saveSettings` regenerates on source/width change and deletes
-  the old derived file (one ever exists). PageSpeed image-delivery fix.
-- Icons are one set: 20px, viewBox 24, stroke 1.8, round caps.
-- Theme default = **system** (no-FOUC script + `ThemeProvider` both `|| 'system'`); the toggle
-  reflects the *applied* theme (`useSyncExternalStore` on `<html>.dark`; server snapshot =
-  light → no hydration mismatch).
-- Two orthogonal axes: **mode** (`.dark`) × **palette** (`data-palette`). `PaletteToggle` /
-  `ThemeToggle` write localStorage + the attribute; the no-FOUC script applies before paint;
-  all palettes' vars are emitted once. (Mechanism rationale → ARCHITECTURE.md.)
-
-## Typography — one source of truth (HARD RULES)
-
-- **No hardcoded text sizes on the public site.** 9 roles (`TypeRole`: `h1–h5`, `body`,
-  `small`, `caption`, `code`), each with size/line-height/letter-spacing → CSS vars
-  `--fs/--lh/--ls-<role>`. Defaults baked into `globals.css :root` and mirrored by
-  `DEFAULT_TYPOGRAPHY` in `lib/themes.ts`. The owner's `settings.typography` is emitted by
-  `typographyToCss()` into the root layout AFTER `globals.css` (also applies in the admin
-  editor `.prose` = WYSIWYG). `smoothing` adds `-webkit-font-smoothing` on `body`.
-- **Where applied:** `.prose` (h1–h5/pre/code/figcaption/table) read the role vars; titles/UI
-  OUTSIDE `.prose` use `.fs-h1…fs-h5` + `.t-small` (every secondary text). H1 = single
-  post/page titles + category/tag headings + draft preview; list cards (`PostCard`) = H2. Only
-  fixed public sizes allowed: the brand wordmark + the 404 numeral.
-- **Inter is self-hosted** (`public/fonts/inter-{latin,latin-ext,vietnamese}.woff2`,
-  variable, declared via `@font-face` + `unicode-range` in `globals.css`; `--font-inter:'Inter'`
-  there). **No `next/font/google`** — it fetched at build, which broke offline/CI builds. The OG
-  route self-hosts the same Inter separately as `.woff` (Satori can't decode woff2). To update
-  Inter, re-drop the woff2 files. The latin subset is `<link rel=preload>`-ed in the root layout.
-- **ONE typeface for EVERYTHING — hard rule, no exceptions (incl. admin + OG).** No
-  `font-family`, no `font-mono`, no second family; `.prose code` is `inherit`;
-  **`grep -rE "font-mono" src` must be empty.** A custom font (`settings.customFont` =
-  family + `faces[]` per weight 400/500/600/700, uploaded via `FontUpload` → `/api/files/font`,
-  Blob `files/font-<weight>-<ms>`, store-relative) overrides `--font-sans` (Inter fallback) —
-  one `@font-face` per weight because faux-bold is disabled (`font-synthesis-weight: none`).
-  `/og` renders Inter + the custom font (`lib/og.ts` `?font=`). Empty = bundled Inter.
-- **Admin chrome does NOT follow the reader's type settings** — it uses Tailwind's standard
-  scale (a fixed design scale); only the admin editor `.prose` mirrors the reader. Don't wire
-  admin chrome to `--fs-*`.
-- Editor exposes H1–H5; `marked` renders `####`/`#####` → `h4`/`h5`.
-
-## PWA
-
-- Installs to the home screen, launches standalone. **No service worker (offline is out of
-  scope by design)** → nothing to register; admin/API are never cached.
-- `app/manifest.ts` (force-dynamic) from settings (name/short_name = title, theme/bg = light
-  palette bg, icons via `resolveAppIcon`). Next auto-injects `<link rel="manifest">` — don't
-  add it by hand.
-- iOS home-screen icon = the **apple-touch-icon** (`generateMetadata` in `app/layout.tsx`);
-  standalone via the manifest's `display:standalone` (iOS 16.4+). Status bar via
-  `generateViewport` → `themeColor`.
-- **Notch / Dynamic Island:** `generateViewport` sets `viewportFit: 'cover'` so the page fills
-  under the island and fixed top bars (the reading-progress bar) reach the true screen edge;
-  `body` re-pads with `env(safe-area-inset-*)` (globals.css) so the header/content clear the
-  island. `env()` is 0 on devices without insets — no effect there. Don't remove one without the
-  other (cover alone tucks the header under the island; padding alone leaves the bar below it).
-- App icon order: `appIconUrl` → `faviconUrl` → bundled `public/app-icon.png`.
-- **Favicon: ONE `<link rel="icon">`, driven only by `generateMetadata`** (`settings.faviconUrl ||
-  '/favicon.ico'`). The default lives in **`public/favicon.ico`, NOT `app/`** — an `app/favicon.ico`
-  is auto-injected by Next ON TOP of the metadata icon, which shipped two conflicting favicons.
-  Don't re-add `app/favicon.ico`.
+- `revalidate = 3600` + `generateStaticParams` (all slugs) + `dynamicParams`. Reads `getPost` +
+  `getPage` (shared `/{slug}` namespace) + `getMedia` (the `<picture>` set). Admin `/admin/*` +
+  search/preview/og are dynamic.
+- **Taxonomy URLs use the SLUGIFIED term** (`lib/taxonomy.ts`): links call `termSlug(term)`, the
+  `category|tag/[slug]` routes call `resolveTerm(...)` → `notFound()` if none. New taxonomy
+  link/route MUST go through these (never hand-encode the name).
 
 ## Conventions (HARD RULES)
 
-- **Repeated chrome shares ONE class constant — never hand-roll per element.** Sibling controls
-  import the same string so they can't drift. Admin nav is a **collapsible left sidebar**
-  (`AdminSidebar.tsx`): each item has an icon (`navIcons.tsx`) + label; a toggle collapses the rail
-  to icon-only (persisted in localStorage; it publishes its width as `--admin-nav-w` so the fixed
-  settings/editor save bars offset past it). Every item — nav links AND theme/palette/cache/sign-out
-  controls — uses `headerActions.ts` `SIDEBAR_NAV` (active links add `SIDEBAR_NAV_ACTIVE`); on mobile
-  it's a hamburger drawer (always icon+label). (`ADMIN_NAV` is the older horizontal variant.)
-  Public header's 40px icon buttons → `ICON_BTN` (`ui/iconButton.ts`). Adding an item = reuse the
-  constant, never copy a class list.
-- **Header/menu alignment must be pixel-exact — the owner is very sensitive and it has drifted
-  repeatedly.** Every header-row item (incl. the bigger brand wordmark) is an
-  `inline-flex h-9 items-center` box; the row is `items-center`. NEVER align a bigger wordmark
-  by `items-baseline` (the recurring bug); never leave an item without the `h-9` box. Verify the
-  rendered result before shipping.
-- **One divider style site-wide:** the global `<hr>` (50% width, left, faint). Never bespoke
-  `border-t`/`border-b` as content dividers; never ALL-CAPS (no `uppercase`) in shipped UI.
-- **Public UI colours come ONLY from theme tokens — never hardcode `neutral-*`/`white`/`black`
-  or a hex.** Vars `--c-bg/text/heading/meta/link/rule` are utilities (`bg-bg`, `text-text`,
-  `text-heading`, `text-meta`, `text-link`, `border-rule`). Every line/border + faint surface
-  (code blocks, hovers, banners) uses `--c-rule`. Admin tooling may stay neutral.
-- **ONE font + NO hardcoded sizes — everywhere (see Typography).**
-  `grep -rE "font-mono|text-\[" src` and public `text-(sm|lg|xl…)` must stay clean.
-- UI text → `src/locales/` only, all languages in sync (see Localization). Code / comments /
-  identifiers / filenames / commits → English. No hardcoded Vietnamese in `lib/` or `api/`
-  (components only).
-- Max 400 lines per file. No `any` (use `unknown` + narrowing).
-- Every API handler: time + log the request, try/catch with logged errors. Auth: only
-  `AUTHORIZED_EMAIL` reaches `/admin`; all write/delete routes are owner-gated server-side (401)
-  via `requireOwner()`. **`src/middleware.ts` is the edge defense-in-depth net** — it reads the
-  NextAuth JWT and blocks `/admin/:path*` (→ sign-in) and owner-only `/api/:path*` (→ 401) even if a
-  new route forgets `requireOwner()`. It **allow-lists self-authed/public paths** (`/api/auth`,
-  `/api/cron`, `/api/track`, `/api/search`, `/api/mcp` except `/api/mcp/tokens`) — a NEW public or
-  bearer/secret-authed API route must be added to `isPublicApi()` there or it gets 401'd. Google is
-  the ONLY sign-in provider.
+- Max 400 lines per file. No `any` (use `unknown` + narrowing). Every API handler: time + log the
+  request, try/catch with logged errors; only `AUTHORIZED_EMAIL` reaches `/admin`; all write/delete
+  routes owner-gated server-side via `requireOwner()` (Invariant 4).
+- **Public UI colours come ONLY from theme tokens** — never hardcode `neutral-*`/`white`/`black`/a
+  hex. **ONE typeface + NO hardcoded sizes everywhere** (`grep -rE "font-mono|text-\[" src` and
+  public `text-(sm|lg|xl…)` must stay clean). **One divider style** (the global `<hr>`); never
+  ALL-CAPS in shipped UI. Repeated chrome shares ONE class constant. *Full detail →
+  `docs/conventions.md`* (typography, header alignment, layout, divider).
+- UI text → `src/locales/` only, all 6 languages in sync (en default, vi/de/ja/zh/ko). Code /
+  comments / identifiers / filenames / commits → English. No hardcoded Vietnamese in `lib/` or
+  `api/` (components only). *Add-a-language / add-a-string steps → `docs/conventions.md`.*
+- **On any behaviour change, update the matching doc in the SAME change** (Working principle #3):
+  CLAUDE.md (rules), the relevant `docs/*`, ARCHITECTURE.md (why), CHANGELOG.md, README.md (versioning
+  + release steps → `docs/conventions.md`).
+- **Do NOT read CHANGELOG.md while coding/debugging** — it's append-only at release time; its history
+  is never needed to fix or understand code.
+
+## Per-area docs (`docs/`)
+
+Read on demand — the DEBUG ROUTER routes to each: `conventions` (typography, header align, layout,
+i18n, scripts, releases) · `features` (Trash, search/ToC/related, editor, dashboards, settings) ·
+`seo-pwa` (SEO, feeds, OG, region, PWA) · `mcp` (server, tokens, OAuth) · `backups` (Drive, cron).
 
 ## Next.js 16
 
-- `params`/`searchParams` are async (await them). Use `PageProps<…>`/`RouteContext<…>` helpers.
-- **DO NOT** set the Supabase GET reads to `no-store`; **avoid** `cacheComponents: true` (PPR —
-  incompatible with `Date.now()` + route configs). See Caching.
-- Before writing any unfamiliar API, read `node_modules/next/dist/docs/` (see `AGENTS.md` —
-  Next 16 differs from training data).
-
-## Docs & releases — keep current
-
-On any behavior change, update the matching doc in the SAME change (Working principle #3):
-- **CLAUDE.md** (this) = rules / data-layer / caching / gotchas. **ARCHITECTURE.md** = overview
-  + why. **CHANGELOG.md** = one entry per user-facing change. **CHECKLIST.md** = pre-deploy
-  steps. **README.md** = setup + features. **ROADMAP.md** = direction.
-- **README is the canonical install/usage doc — keep it current.** Its **two install paths**
-  (1️⃣ do-it-yourself, 2️⃣ hand-to-an-AI-agent) + the **MCP "let an agent write & publish"** section
-  + the **env-var table** must be updated in the SAME change whenever setup/deploy/env/auth/MCP/backup
-  behavior changes (new/renamed env var, a new owner setup step, a changed redirect URI, etc.).
-  Never let the README drift from how the app is actually installed and run.
-- Keep personal/instance values (credentials, Vercel/Blob IDs, the live domain) OUT of tracked
-  files — `.env.local` + Vercel only.
-- **Audits** (`audit/`): a full review per `audit/README.md` → dated `audit/YYYY-MM-DD-<scope>.md`;
-  read the latest first so a pass starts from the last clean line.
-- **Versioning (owner's rule — do NOT auto-bump):** the version is **`1.0.x`** (was `0.9.x`; the
-  owner cut **1.0.0** with the MCP + Trash release). Each change bumps the patch `x`
-  (→ `1.0.999`), a running counter with no semver meaning. NEVER raise `1.0` → `1.1` or `→ 2.0`
-  unless the owner asks. A code change bumps `x`; pure-docs may skip. On a bump, also update the
-  **README title** version: `` # vibe**blog** `v1.0.x` `` (centered header, top of README).
-- **Cutting a release:** `x` already current; `npm run build` + `npm run lint` exit 0; push `main`;
-  `gh release create v1.0.<x> --title "v1.0.<x> - <tagline>" --notes "…"`.
+`params`/`searchParams` are async; use `PageProps<…>`/`RouteContext<…>`. DB-read cache rules → Caching
+(`no-store` + `cacheComponents:true` forbidden). Unfamiliar API → read `node_modules/next/dist/docs/` (`AGENTS.md`).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# vibe**blog** &nbsp;`v1.0.17`
+# vibe**blog** &nbsp;`v1.0.18`
 
 **An AI-operated personal blog platform.**
 Write and publish from a clean multilingual admin — or hand the keys to an AI agent and let it write, publish, and even deploy for you.
@@ -155,7 +155,7 @@ npx auth secret                   # AUTH_SECRET
 npm run dev                       # http://localhost:3000/admin
 ```
 
-Point the same Supabase + Blob at local, and add `http://localhost:3000/api/auth/callback/google` to your Google client. `npm run build` + `npm run lint` must both pass (strict `tsc`, no `any`).
+Point the same Supabase + Blob at local, and add `http://localhost:3000/api/auth/callback/google` to your Google client. `npm run check:all` must pass before any change is done (typecheck + lint + invariant checks + the vitest seam tests; offline, no creds); `npm run build` for a release.
 
 ---
 

--- a/audit/README.md
+++ b/audit/README.md
@@ -18,13 +18,18 @@ Work top to bottom. For each finding: fix it in the same pass when safe, or reco
 it as a follow-up if it needs a decision. Nothing is "noted and skipped" silently.
 
 ### 0. Baseline — must be green before reviewing anything
-- [ ] `npx tsc --noEmit` exits 0 (also proves all 6 locales are key-complete via `satisfies`)
-- [ ] `npm run lint` exits 0
+- [ ] **`npm run check:all` exits 0** — the one-command baseline. Bundles `tsc --noEmit` (also
+      proves all 6 locales key-complete via `satisfies`) + `npm run lint` + the codified invariant
+      checks (`check:routes`/`check:filesize`/`check:no-any`, see §1/§4) + the `npm test` seam net.
 - [ ] `npm run build` exits 0; `/` and `/[slug]` are `○`/`●` (ISR), admin is `ƒ` (dynamic)
+      (kept separate from `check:all` — build is slow + not needed offline)
+- [ ] (live, optional) `npm run check:consistency:live` — media/files ⇄ Blob integrity (§2);
+      skips cleanly without `.env.local` creds
 
 ### 1. Security
-- [ ] EVERY write/delete (and owner-only read) API route calls `requireOwner()` first
-      (`grep -L requireOwner src/app/api/**/route.ts` — only the NextAuth handler may lack it)
+- [ ] EVERY write/delete (and owner-only read) API route calls `requireOwner()` first.
+      **Codified: `npm run check:routes`** (allowlist mirrors `middleware.ts isPublicApi()`).
+      Reference grep: `grep -L requireOwner src/app/api/**/route.ts`.
 - [ ] `/admin` guarded server-side (admin layout `getAuthState` → redirect)
 - [ ] Every `dangerouslySetInnerHTML` source is safe: markdown raw HTML is escaped;
       palette colors are hex-validated; `customCss` strips `</style`; JSON-LD escapes `<`
@@ -36,9 +41,15 @@ it as a follow-up if it needs a decision. Nothing is "noted and skipped" silentl
 
 ### 2. Logic / correctness
 - [ ] Cache invalidation in `revalidate.ts` is a SUPERSET of affected surfaces (never under-purges)
-- [ ] No read-after-write races (Blob reads are `?ts`-busted; index writes read-modify-write)
+      (**codified: `revalidate.test.ts`** in `npm test`)
+- [ ] media/files rows ⇄ Blob store stay consistent (**codified: `npm run check:consistency:live`** —
+      manifest→blob missing + blob→manifest orphan, both directions, incl. trashed rows + settings refs)
 - [ ] No data-loss paths (e.g. an audit/cleanup that ignores `revisions/` snapshots)
-- [ ] Slug namespace shared by posts + pages is enforced (`ensureSlugFree`)
+- [ ] Slug namespace shared by posts + pages is enforced (`ensureSlugFree`) (**codified: `slugs.test.ts`**)
+- [ ] Every live read filters `.is('deleted_at', null)` — trashed content never leaks
+      (**codified: `soft-delete.test.ts`**, listing/public/search/single)
+- [ ] Asymmetric cache-bust: `backup_state` writes bust `db`, MCP token routes do NOT
+      (**codified: `npm run check:token-bust`**)
 - [ ] Drafts + future-dated posts hidden from every public surface
 
 ### 3. Performance
@@ -47,8 +58,10 @@ it as a follow-up if it needs a decision. Nothing is "noted and skipped" silentl
 - [ ] No accidental `force-dynamic` on a public page (would kill ISR); admin stays dynamic
 
 ### 4. Code quality
-- [ ] No file > 400 lines (`find src -name '*.ts*' | xargs wc -l | sort -rn | head`)
+- [ ] No file > 400 lines (**codified: `npm run check:filesize`**;
+      reference: `find src -name '*.ts*' | xargs wc -l | sort -rn | head`)
 - [ ] No `any` (only in comments), no stray `console.log`/`TODO`/`FIXME`, no `@ts-ignore`
+      (**codified: `npm run check:no-any`**; sanctioned console.log → `// check:allow-console`)
 
 ### 5. Layout / visual (owner is very sensitive here)
 - [ ] Sibling controls share ONE class constant — never hand-rolled duplicates:

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -1,0 +1,36 @@
+> Split from CLAUDE.md — read when touching backups: Google Drive auth, restore, the backup cron, `backup_state`, `lib/backup.ts`, `lib/gdrive.ts`.
+
+# Backups — Google Drive (Admin → Settings → Advanced)
+
+- **What it is.** A full-site snapshot to the owner's Google Drive: one self-contained
+  `.tar.gz` = `db.json` (every text table except `backup_state`) + `blob/<pathname>` (every
+  binary) + `manifest.json`. Built in `/tmp` then resumable-uploaded into a `vibeblog-backups`
+  Drive folder. Runs on a schedule (cron, every `settings.backups.intervalDays`, default 4) or
+  the "Back up now" button; retention keeps the newest `settings.backups.keep` (default 4).
+- **Auth is SEPARATE from sign-in.** A dedicated `drive.file` OAuth flow (reuses the Google
+  client `AUTH_GOOGLE_*`, never touches the login scope): `GET /api/backup/connect` → Google
+  consent → `GET /api/backup/callback` exchanges the code for a **refresh token**, stored in
+  `backup_state` (server-only). `drive.file` = the app only ever sees files IT created. The
+  **redirect URI is `backupRedirectUri(settings)` = `${resolveSiteUrl(settings)}/api/backup/callback`**
+  — derived from the canonical site URL, NOT `req.nextUrl.origin` (which is a `*.vercel.app` host
+  when the admin is opened there → `redirect_uri_mismatch`). So the URI registered on the OAuth
+  client must use the canonical host (`settings.siteUrl`).
+- **Secret hygiene (HARD RULE).** The Drive refresh token must NEVER reach the client. It lives
+  in `backup_state`, NOT in `settings.data` (which is sent to the admin). Only non-secret config
+  (`enabled`/`intervalDays`/`keep`) lives in `settings.backups` and flows through the settings
+  form; the connection + snapshot list come from owner-only `/api/backup` (returns `toStatus`,
+  never the token) — same split as MCP tokens.
+- **`backup_state` writes MUST `revalidateTag(DB_TAG, 'max')`** (`backup-state.ts`:
+  `setDriveAuth`/`clearDriveAuth`/`setFolderId`/`recordRun`). The state read is Data-Cache-eligible
+  (tag `db`, 1h) and is read by BOTH `/api/backup` and the admin Overview — `force-dynamic` on one
+  route is NOT enough to dodge the *shared* Data Cache, so without busting it the admin showed stale
+  "not connected" after a successful connect (the bug that shipped in 1.0.11–1.0.13).
+- **Restore is DESTRUCTIVE** (`POST /api/backup/restore`): replaces every text table (settings
+  upserted by id=1; others delete-all then insert with `id`/`search` stripped) and re-uploads
+  every blob. A **pre-restore snapshot is taken first**. UI confirms before calling.
+- **Routes:** `/api/backup` (GET status+list, POST run-now, DELETE `?id=`), `/api/backup/restore`,
+  `/api/backup/{connect,callback,disconnect}`. All owner-only (middleware + `requireOwner`); the
+  cron calls `maybeRunBackup()` directly (no HTTP). New mutating action? `logActivity('backup.*')`.
+- **Owner setup (one-time):** enable the **Google Drive API** in the Cloud project behind
+  `AUTH_GOOGLE_ID`, add `https://<domain>/api/backup/callback` (+ localhost) as an Authorized
+  redirect URI on the OAuth client, then click **Connect Google Drive**. No new env var.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,124 @@
+> Split from CLAUDE.md — read when touching typography, header/menu alignment, layout/divider, i18n, scripts, or releases. Hard rules used everywhere stay in [`CLAUDE.md`](../CLAUDE.md); this file is the per-area detail.
+
+# Conventions (detail)
+
+## Localization — `src/locales/`
+
+- `types.ts` = shapes (`Dict` public, `AdminStrings` admin). Add a key → every locale file
+  must define it (`satisfies` → build error otherwise = the no-missing-keys guarantee).
+- `langs.ts` = `SITE_LANGS` + `isSiteLang`. Public `src/locales/<code>.ts`, admin
+  `src/locales/admin/<code>.ts`. Supported: **en (default), vi, de, ja, zh, ko** (CJK via
+  `system-ui` fallback — Inter has no CJK glyphs).
+- **Add a language:** extend `SiteLang`, add a `SITE_LANGS` row + a `DATE_LOCALE` entry in
+  `i18n.ts` + both locale files.
+- **Add/rename a string:** add to `types.ts`, then fill ALL locale files. Build fails until
+  complete. **Keep every locale in sync on any UI string change.**
+
+## Header (public) — alignment is a HARD RULE
+
+- Logo + the icon row share ONE flex line (`items-center`) so icons stay on the logo's
+  vertical midline; the description sits below.
+- **The logo is auto-sized, never the raw original.** `settings.logoUrl` = the owner's
+  untouched source; the header renders `settings.logoRenderUrl` (small WebP scaled to
+  `logoWidth` @2x for retina, built on save by `renderLogo` in `files.ts`), falling back to
+  the original only for vector/animated logos. The `<img>` carries `width`+`height`
+  (`logoRenderHeight`) → no CLS. `saveSettings` regenerates on source/width change and deletes
+  the old derived file (one ever exists). PageSpeed image-delivery fix.
+- Icons are one set: 20px, viewBox 24, stroke 1.8, round caps.
+- Theme default = **system** (no-FOUC script + `ThemeProvider` both `|| 'system'`); the toggle
+  reflects the *applied* theme (`useSyncExternalStore` on `<html>.dark`; server snapshot =
+  light → no hydration mismatch).
+- Two orthogonal axes: **mode** (`.dark`) × **palette** (`data-palette`). `PaletteToggle` /
+  `ThemeToggle` write localStorage + the attribute; the no-FOUC script applies before paint;
+  all palettes' vars are emitted once. (Mechanism rationale → ARCHITECTURE.md.)
+
+## Typography — one source of truth (HARD RULES)
+
+- **No hardcoded text sizes on the public site.** 9 roles (`TypeRole`: `h1–h5`, `body`,
+  `small`, `caption`, `code`), each with size/line-height/letter-spacing → CSS vars
+  `--fs/--lh/--ls-<role>`. Defaults baked into `globals.css :root` and mirrored by
+  `DEFAULT_TYPOGRAPHY` in `lib/themes.ts`. The owner's `settings.typography` is emitted by
+  `typographyToCss()` into the root layout AFTER `globals.css` (also applies in the admin
+  editor `.prose` = WYSIWYG). `smoothing` adds `-webkit-font-smoothing` on `body`.
+- **Where applied:** `.prose` (h1–h5/pre/code/figcaption/table) read the role vars; titles/UI
+  OUTSIDE `.prose` use `.fs-h1…fs-h5` + `.t-small` (every secondary text). H1 = single
+  post/page titles + category/tag headings + draft preview; list cards (`PostCard`) = H2. Only
+  fixed public sizes allowed: the brand wordmark + the 404 numeral.
+- **Inter is self-hosted** (`public/fonts/inter-{latin,latin-ext,vietnamese}.woff2`,
+  variable, declared via `@font-face` + `unicode-range` in `globals.css`; `--font-inter:'Inter'`
+  there). **No `next/font/google`** — it fetched at build, which broke offline/CI builds. The OG
+  route self-hosts the same Inter separately as `.woff` (Satori can't decode woff2). To update
+  Inter, re-drop the woff2 files. The latin subset is `<link rel=preload>`-ed in the root layout.
+- **ONE typeface for EVERYTHING — hard rule, no exceptions (incl. admin + OG).** No
+  `font-family`, no `font-mono`, no second family; `.prose code` is `inherit`;
+  **`grep -rE "font-mono" src` must be empty.** A custom font (`settings.customFont` =
+  family + `faces[]` per weight 400/500/600/700, uploaded via `FontUpload` → `/api/files/font`,
+  Blob `files/font-<weight>-<ms>`, store-relative) overrides `--font-sans` (Inter fallback) —
+  one `@font-face` per weight because faux-bold is disabled (`font-synthesis-weight: none`).
+  `/og` renders Inter + the custom font (`lib/og.ts` `?font=`). Empty = bundled Inter.
+- **Admin chrome does NOT follow the reader's type settings** — it uses Tailwind's standard
+  scale (a fixed design scale); only the admin editor `.prose` mirrors the reader. Don't wire
+  admin chrome to `--fs-*`.
+- Editor exposes H1–H5; `marked` renders `####`/`#####` → `h4`/`h5`.
+
+## Chrome reuse, divider, colour (HARD RULES)
+
+- **Repeated chrome shares ONE class constant — never hand-roll per element.** Sibling controls
+  import the same string so they can't drift. Admin nav is a **collapsible left sidebar**
+  (`AdminSidebar.tsx`): each item has an icon (`navIcons.tsx`) + label; a toggle collapses the rail
+  to icon-only (persisted in localStorage; it publishes its width as `--admin-nav-w` so the fixed
+  settings/editor save bars offset past it). Every item — nav links AND theme/palette/cache/sign-out
+  controls — uses `headerActions.ts` `SIDEBAR_NAV` (active links add `SIDEBAR_NAV_ACTIVE`); on mobile
+  it's a hamburger drawer (always icon+label). (`ADMIN_NAV` is the older horizontal variant.)
+  Public header's 40px icon buttons → `ICON_BTN` (`ui/iconButton.ts`). Adding an item = reuse the
+  constant, never copy a class list.
+- **Header/menu alignment must be pixel-exact — the owner is very sensitive and it has drifted
+  repeatedly.** Every header-row item (incl. the bigger brand wordmark) is an
+  `inline-flex h-9 items-center` box; the row is `items-center`. NEVER align a bigger wordmark
+  by `items-baseline` (the recurring bug); never leave an item without the `h-9` box. Verify the
+  rendered result before shipping.
+- **One divider style site-wide:** the global `<hr>` (50% width, left, faint). Never bespoke
+  `border-t`/`border-b` as content dividers; never ALL-CAPS (no `uppercase`) in shipped UI.
+- **Public UI colours come ONLY from theme tokens — never hardcode `neutral-*`/`white`/`black`
+  or a hex.** Vars `--c-bg/text/heading/meta/link/rule` are utilities (`bg-bg`, `text-text`,
+  `text-heading`, `text-meta`, `text-link`, `border-rule`). Every line/border + faint surface
+  (code blocks, hovers, banners) uses `--c-rule`. Admin tooling may stay neutral.
+
+## Scripts — `scripts/`
+
+`node --env-file=.env.local scripts/<name>.mjs [--dry]` — idempotent.
+
+- **`schema.sql`** — full Postgres schema (11 tables + indexes + `posts.search` tsvector +
+  RLS + the analytics RPCs). Run ONCE on a fresh Supabase project. NOT run by the app;
+  transcribed from the live schema — **keep it in sync when you change tables/RPCs.**
+- **`migrate-to-supabase.mjs`** — one-off P1.5 migration (Blob `_index.json`+`.md` →
+  Postgres). Already run; kept for recovery.
+- **`scripts/legacy/` — pre-Supabase one-offs, do NOT run against the live site** (they operate
+  on the retired Blob `_index.json`/`.md` model): `import-wordpress`, `convert-html-to-markdown`,
+  `fix-import-captions`, `backfill-excerpts`, `rehost-images`, `rebuild-index`, `wipe-media`,
+  `backfill-reading-time`, `list-posts-with-images`, `check-image-links`,
+  `backfill-media-dimensions`, `remap-original-images`. Kept for recovery only; their deps
+  (`gray-matter`/`turndown`/`turndown-plugin-gfm`/`fast-xml-parser`) are devDependencies.
+
+## Docs & releases — keep current
+
+On any behavior change, update the matching doc in the SAME change (Working principle #3):
+- **CLAUDE.md** = rules / data-layer / caching / gotchas. **ARCHITECTURE.md** = overview
+  + why. **CHANGELOG.md** = one entry per user-facing change. **CHECKLIST.md** = pre-deploy
+  steps. **README.md** = setup + features. **ROADMAP.md** = direction.
+- **README is the canonical install/usage doc — keep it current.** Its **two install paths**
+  (1️⃣ do-it-yourself, 2️⃣ hand-to-an-AI-agent) + the **MCP "let an agent write & publish"** section
+  + the **env-var table** must be updated in the SAME change whenever setup/deploy/env/auth/MCP/backup
+  behavior changes (new/renamed env var, a new owner setup step, a changed redirect URI, etc.).
+  Never let the README drift from how the app is actually installed and run.
+- Keep personal/instance values (credentials, Vercel/Blob IDs, the live domain) OUT of tracked
+  files — `.env.local` + Vercel only.
+- **Audits** (`audit/`): a full review per `audit/README.md` → dated `audit/YYYY-MM-DD-<scope>.md`;
+  read the latest first so a pass starts from the last clean line.
+- **Versioning (owner's rule — do NOT auto-bump):** the version is **`1.0.x`** (was `0.9.x`; the
+  owner cut **1.0.0** with the MCP + Trash release). Each change bumps the patch `x`
+  (→ `1.0.999`), a running counter with no semver meaning. NEVER raise `1.0` → `1.1` or `→ 2.0`
+  unless the owner asks. A code change bumps `x`; pure-docs may skip. On a bump, also update the
+  **README title** version: `` # vibe**blog** `v1.0.x` `` (centered header, top of README).
+- **Cutting a release:** `x` already current; `npm run build` + `npm run lint` exit 0; push `main`;
+  `gh release create v1.0.<x> --title "v1.0.<x> - <tagline>" --notes "…"`.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,91 @@
+> Split from CLAUDE.md — read when touching a feature area: Trash, reading/discovery (search, ToC, related, preview), the editor, the content dashboard, activity log + system panel, or settings.
+
+# Feature areas
+
+## Trash (soft delete) — Admin → Trash (`/admin/trash`)
+
+- **Every delete is a soft delete.** `posts`/`pages`/`media`/`files` each have a nullable
+  `deleted_at` (NULL = live, timestamp = trashed). `deleteX()` sets `deleted_at`; nothing is
+  hard-deleted on a normal delete. EVERY live read filters `.is('deleted_at', null)`
+  (index/search/getPost, page index/getPage, media/file lists, the finalize sweeps) so trashed
+  items leave the site, lists, search, sitemap/feed/llms and the libraries at once.
+- **Media/file soft delete KEEPS the blob** — a published post linking a trashed image keeps
+  rendering; the blob is removed only on purge. So `/api/media/delete` no longer purges the page
+  cache (it used to). A trashed row **keeps its slug** (still reserved via `ensureSlugFree`) so
+  restore never collides.
+- Per kind the lib exports `restoreX`, `purgeX` (hard delete: row + revisions/blobs),
+  `getTrashedX`, `emptyXTrash`. The Trash page server-loads all four lists; `TrashView` (4 tabs)
+  acts via **`POST /api/trash`** `{ kind, action: restore|purge|empty, ids? }` (owner-gated) then
+  `router.refresh()`. **Nothing auto-purges** — permanent removal is manual (per-item or Empty
+  trash). Restores revalidate the item's surfaces; media/file purges `revalidateEverything()`.
+- Adding a mutating trash action → log it (activity actions `*.restore` / `*.purge` /
+  `trash.empty`) and keep the i18n keys in sync.
+
+## Reading & discovery
+
+- Features `{ search, toc, related, readingTime, progressBar, activityLog }` (default on,
+  Admin → Settings → Tính năng); gated in header / `/search` / post page.
+- `/search` — **two layers:** a lean local index (`{slug,title,date,terms}`, instant +
+  accent-insensitive) merged with `GET /api/search?q=` (Postgres FTS over title + BODY via
+  `searchPosts` `.textSearch('search', …, {config:'simple'})`). **NOTE:** `simple` is accent-
+  *sensitive* — accent-insensitivity comes from the local layer only. Header search =
+  `SearchOverlay` (modal); the `/search` route stays for deep links / no-JS.
+- Post page: `ReadingProgress`, `BackToTop`, `Toc` (≥3 H2/H3; desktop-only, sticky in the
+  left gutter; `PostContent` assigns slug ids), `RelatedPosts` (`getRelatedPosts`: shared
+  tags ×2 + categories).
+- **GOTCHA:** the global unlayered `hr { margin:0 }` beats Tailwind margin utilities — put
+  divider spacing on a wrapper div, not on the `<hr>`.
+- **Heading ids are de-duped** (2nd `foo` → `foo-2`): `dedupeHeadingIds` (PostContent) and
+  `extractHeadings` (utils) run the SAME counter over H2/H3 in document order — change one, change
+  both or the ToC anchors break.
+- **Link hrefs are sanitized** (`safeHref` in PostContent drops `javascript:`/`data:`/`vbscript:`)
+  — marked v5+ no longer does. Raw HTML in markdown is already escaped (the `html` renderer →
+  `escapeHtml`), so `<script>`/`<img onerror>` render as visible text.
+- **Draft preview:** `/preview/[slug]?key=<hmac>` (force-dynamic, noindex);
+  `previewToken` = HMAC(slug, `AUTH_SECRET`); editor "Link nháp" button. Separate route keeps
+  `/[slug]` SSG + published-only.
+
+## Editor (Admin → editor) — `components/admin/Editor.tsx`
+
+- StarterKit + underline, inline code, bullet/numbered/**task** lists (GFM `- [ ]`), quote,
+  code block, hr, link, captioned image, GFM tables, video. `tiptap-markdown` serializes all.
+  **GOTCHA:** list items wrap content in `<p>`; `.prose li > p{margin:0}` keeps them tight.
+- Autosave every 60s while dirty (chained behind any in-flight save); warns on unload.
+- Time machine: each overwrite snapshots the prior version (`revisions.ts`, keeps 3); restore
+  loads it into the editor (non-destructive — current version is snapshotted on next save).
+
+## Content dashboard (Admin → content)
+
+- 3 tabs: Bài viết / Trang / Phân loại; "new" hidden on taxonomy.
+- `RowActions` (shared): open-in-new (PUBLISHED only) + edit + delete; exports the `ICON_BTN`
+  chrome for reuse. `StatusPill` never wraps.
+- Tables are mobile-responsive by **hiding secondary columns** (not horizontal scroll): posts
+  hide Date (`sm`) + Categories (`md`); pages hide slug (`sm`). Title + Status + actions always show.
+- `PostsTable` filter bar: substring search + All/Published/Draft (client-side).
+- `TaxonomyManager`: rename (merge) / remove terms across all posts → `updateTerm`.
+
+## Activity log + System panel (Admin)
+
+- **Activity log:** every mutating route does `after(() => logActivity(action, detail))`
+  (post/page CRUD, media/file/icon/font, settings, taxonomy, cache.clear, backup.*). Gated by
+  `features.activityLog`. Admin → Log (force-dynamic, latest 200, Clear). **Adding a mutating
+  route → log it too.**
+- **System panel** (admin Overview, `getSystemInfo()`): hosting/URL/region/env/git + database
+  (Supabase, live reachability) + Blob host + **MCP on/off** + **Backups on** (= enabled AND Drive
+  connected); rows may deep-link. The stat cards split media into **originals / variants / files**
+  (variants = blobs matching `-(thumb|NNNN).(avif|webp)`); category/tag cards show their total count.
+- **Analytics:** Admin → Analytics (24h/7d/30d/1y); a View column on the content tables
+  (`getViewTotals`). Detail in the data-layer map (`analytics.ts`).
+
+## Settings (Admin → settings) — `SettingsView.tsx`
+
+- **ONE form, ONE save button, THREE tabs** (`general | appearance | advanced`; tab state not
+  persisted). One `useState<SiteSettings>` → one PUT `/api/settings`.
+- Controlled field groups (no own state/save): General `SiteFields`/`LayoutMenuFields`/
+  `FeatureFields`/`SeoFields`; Appearance `ThemeFields`/`FontUpload`/`TypographyFields`/
+  `AdvancedFields` (font smoothing = "Text rendering"); Advanced `McpFields` + custom-CSS.
+  `McpFields` is the EXCEPTION to "no own state/save": the MCP enable toggle flows through the
+  settings form, but its token manager has its own `/api/mcp/tokens` API (plaintext shown once).
+- Each tab: `grid lg:grid-cols-2 items-start` (explicit columns, NOT CSS `columns`).
+- **Save calls `router.refresh()`** so the admin shell + public header reflect the change
+  immediately.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,32 @@
+> Split from CLAUDE.md — read when touching the MCP server (`/api/mcp`, `src/lib/mcp/`), its tokens, or the OAuth flow.
+
+# MCP server — `/api/mcp` + `src/lib/mcp/`
+
+- **What it is.** A remote MCP endpoint (Streamable HTTP, `mcp-handler` + `@modelcontextprotocol/sdk`)
+  that lets an MCP client (Claude/ChatGPT) operate the blog. Tools are THIN wrappers over the same
+  `lib/` functions the admin routes use — same slug rules, revisions, soft-delete, revalidation,
+  activity log. **Off unless the owner enables it** (Admin → Settings → Advanced toggle,
+  `settings.mcp.enabled`); `verifyMcpToken` 401s every call while off.
+- **Auth = admin-managed tokens + thin OAuth.** Manual tokens are created in the admin (up to 5,
+  named, shown ONCE on creation — only the SHA-256 hash is kept in the `mcp_tokens` table; see
+  `lib/mcp/tokens.ts`). Every token **expires 180 days after creation** (`expires_at`, set on insert,
+  default in `schema.sql`); `verifyMcpToken` hashes the bearer, looks it up, **rejects it once past
+  `expires_at`**, else stamps `last_used_at` (while the toggle is on). There is **no `MCP_TOKEN` env
+  var.** Connectors that require OAuth run a minimal OAuth 2.1 authorization-code + PKCE flow gated by
+  the owner's NextAuth login (`src/app/api/mcp/{authorize,token,register}` + `src/app/.well-known/oauth-*`);
+  the `/token` exchange **mints a 180-day token via `mintOAuthToken`** (named "OAuth connector") and
+  returns it. **OAuth tokens are exempt from the manual 5-cap and are NEVER auto-deleted** (an expired
+  row lingers as dead until the owner deletes it; a connector silently re-authorizes to mint a fresh one).
+  **Lifecycle rule: the admin is the SOLE authority over a connection** — beyond the 180-day expiry a
+  token persists (no prune) until the OWNER deletes it in the admin; deleting the connector in Claude
+  alone just lets it re-authorize (a new token). So authorize once = stays connected (connector
+  re-auths across the 180-day boundary), and an admin delete is final unless the owner re-authorizes.
+  (A reconnect mints a new row; the prior one persists until the owner removes it — the admin
+  lists/deletes them all.) Codes are HMAC-signed
+  (`MCP_OAUTH_SECRET` → falls back to `AUTH_SECRET`) in `lib/mcp/auth.ts`. Token CRUD: owner-only
+  `/api/mcp/tokens` (+ `/[id]`); UI in `components/admin/McpFields.tsx` (cap counts manual only).
+- **Tools** (`lib/mcp/tools.ts` posts/pages/taxonomy, `tools-library.ts` media/files/settings;
+  results via `result.ts`). Content is Markdown verbatim — no HTML conversion. Deletes are soft
+  (→ Trash). **`update_settings` exposes only a safe allowlist (title/description/showDescription)** —
+  the zod inputSchema IS the allowlist, so sensitive settings can't be written over MCP. `get_settings`
+  reads all. **Adding a tool that mutates → revalidate + `logActivity` like the admin routes.**

--- a/docs/seo-pwa.md
+++ b/docs/seo-pwa.md
@@ -1,0 +1,49 @@
+> Split from CLAUDE.md — read when touching SEO toggles, sitemap/feed/llms/robots, OG image, the deploy region, PWA, or the web manifest.
+
+# SEO, deploy region & PWA
+
+## Region (latency)
+
+`vercel.json` pins functions to **`sin1` (Singapore)**; the Blob store is in Singapore
+too (co-located reads, no cross-region hop). The OG route is `runtime = 'edge'`. (Self-host:
+change/remove `regions` for your audience — see README.)
+
+## SEO (toggleable, Admin → Settings → SEO)
+
+- `settings.seo` = `{ autoSchema, sitemap, llms, robots, rss, ogImage, ogFallbackImage }` +
+  `settings.siteUrl` (canonical; '' → `VERCEL_PROJECT_PRODUCTION_URL` → localhost via
+  `resolveSiteUrl()`). Drives `metadataBase`.
+- `robots.ts` — always disallows `/admin`+`/api`; when on, a 3-group policy: search +
+  reputable AI bots allowed (`SEARCH_BOTS`/`AI_BOTS`, paired with `/llms.txt`), scrapers
+  (`BAD_BOTS`: Ahrefs/Semrush/…) `Disallow: /`, `*` welcoming. Lists are consts atop the file.
+- `sitemap.ts` — home + posts + pages + categories + tags; each post lists its images
+  (`<image:image>`). `sitemaps.xml` → 308 to `/sitemap.xml`.
+- `llms.txt` (markdown content index, 404 off) · `feed.xml` (RSS 50, 404 off, auto-discovered).
+- `og/route.tsx` — dynamic OG (1200×630, **edge**, Inter `.woff` subsets bundled); query
+  `title`/`site`/`bg` + optional `?font=<blobUrl>` (Blob host only, SSRF-guarded). `lib/og.ts`
+  builds the card URLs (`ogImageUrl` posts/pages, `ogCardUrl`+`siteDomain` lists); honors
+  `seo.ogImage`; appends `font=` when a custom font is set.
+- JSON-LD via `JsonLd.tsx` (`websiteSchema` home, `articleSchema` posts), gated `seo.autoSchema`.
+- robots/sitemap/feed/llms are ISR; an SEO toggle is a settings save → `revalidateEverything()`;
+  post create/edit purges feed/sitemap/llms.
+
+## PWA
+
+- Installs to the home screen, launches standalone. **No service worker (offline is out of
+  scope by design)** → nothing to register; admin/API are never cached.
+- `app/manifest.ts` (force-dynamic) from settings (name/short_name = title, theme/bg = light
+  palette bg, icons via `resolveAppIcon`). Next auto-injects `<link rel="manifest">` — don't
+  add it by hand.
+- iOS home-screen icon = the **apple-touch-icon** (`generateMetadata` in `app/layout.tsx`);
+  standalone via the manifest's `display:standalone` (iOS 16.4+). Status bar via
+  `generateViewport` → `themeColor`.
+- **Notch / Dynamic Island:** `generateViewport` sets `viewportFit: 'cover'` so the page fills
+  under the island and fixed top bars (the reading-progress bar) reach the true screen edge;
+  `body` re-pads with `env(safe-area-inset-*)` (globals.css) so the header/content clear the
+  island. `env()` is 0 on devices without insets — no effect there. Don't remove one without the
+  other (cover alone tucks the header under the island; padding alone leaves the bar below it).
+- App icon order: `appIconUrl` → `faviconUrl` → bundled `public/app-icon.png`.
+- **Favicon: ONE `<link rel="icon">`, driven only by `generateMetadata`** (`settings.faviconUrl ||
+  '/favicon.ico'`). The default lives in **`public/favicon.ico`, NOT `app/`** — an `app/favicon.ico`
+  is auto-injected by Next ON TOP of the metadata icon, which shipped two conflicting favicons.
+  Don't re-add `app/favicon.ico`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibeblog",
-  "version": "1.0.10",
+  "version": "1.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibeblog",
-      "version": "1.0.10",
+      "version": "1.0.17",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
@@ -45,7 +45,8 @@
         "tailwindcss": "^4",
         "turndown": "^7.2.4",
         "turndown-plugin-gfm": "^1.0.2",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.9"
       },
       "engines": {
         "node": ">=20.9"
@@ -1454,6 +1455,16 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
@@ -1527,6 +1538,281 @@
       "peerDependencies": {
         "@redis/client": "^1.0.0"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -1633,6 +1919,13 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -2505,6 +2798,24 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -3293,6 +3604,119 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -3590,6 +4014,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -3861,6 +4295,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -4431,6 +4875,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -4931,6 +5382,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4992,6 +5453,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -5311,6 +5782,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -7581,6 +8067,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -7790,6 +8290,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8359,6 +8866,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
     "node_modules/rope-sequence": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
@@ -8764,6 +9305,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -8803,6 +9351,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -8811,6 +9366,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -9119,6 +9681,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -9165,6 +9744,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tiptap-markdown": {
@@ -9686,6 +10275,200 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -9794,6 +10577,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeblog",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "private": true,
   "license": "MIT",
   "browserslist": [
@@ -14,7 +14,15 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "check:routes": "node scripts/checks/routes-guarded.mjs",
+    "check:filesize": "node scripts/checks/file-size.mjs",
+    "check:no-any": "node scripts/checks/no-any.mjs",
+    "check:token-bust": "node scripts/checks/token-no-public-bust.mjs",
+    "check:consistency:live": "node scripts/checks/consistency.mjs",
+    "check:all": "npm run typecheck && npm run lint && npm run check:routes && npm run check:filesize && npm run check:no-any && npm run check:token-bust && npm test"
   },
   "engines": {
     "node": ">=20.9"
@@ -56,6 +64,7 @@
     "tailwindcss": "^4",
     "turndown": "^7.2.4",
     "turndown-plugin-gfm": "^1.0.2",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.9"
   }
 }

--- a/scripts/checks/_util.mjs
+++ b/scripts/checks/_util.mjs
@@ -1,0 +1,101 @@
+// Shared helpers for the static invariant checks. Node-only, zero deps.
+import { readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Recursively list files under `dir` matching `test(path)`.
+export function walk(dir, test) {
+  const out = []
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name)
+    if (statSync(p).isDirectory()) out.push(...walk(p, test))
+    else if (test(p)) out.push(p)
+  }
+  return out
+}
+
+export const isTs = (p) => /\.(ts|tsx)$/.test(p)
+export const isTest = (p) => /\.(test|spec)\.(ts|tsx)$/.test(p)
+
+// Line count matching `wc -l` (count newlines).
+export function lineCount(content) {
+  const nl = (content.match(/\n/g) || []).length
+  return content.endsWith('\n') || content.length === 0 ? nl : nl + 1
+}
+
+// Replace every comment + string/template body with spaces, preserving newlines
+// and offsets, so a regex for code tokens (any, console.log) ignores comments and
+// string literals. TODO/FIXME/@ts-ignore are scanned on the RAW text instead.
+export function stripCommentsAndStrings(src) {
+  let out = ''
+  let state = 'code' // code | line | block | sq | dq | tpl
+  for (let i = 0; i < src.length; ) {
+    const c = src[i]
+    const d = src[i + 1]
+    if (state === 'code') {
+      if (c === '/' && d === '/') { state = 'line'; out += '  '; i += 2; continue }
+      if (c === '/' && d === '*') { state = 'block'; out += '  '; i += 2; continue }
+      if (c === "'") { state = 'sq'; out += ' '; i++; continue }
+      if (c === '"') { state = 'dq'; out += ' '; i++; continue }
+      if (c === '`') { state = 'tpl'; out += ' '; i++; continue }
+      out += c; i++; continue
+    }
+    if (state === 'line') {
+      if (c === '\n') { state = 'code'; out += '\n' } else out += ' '
+      i++; continue
+    }
+    if (state === 'block') {
+      if (c === '*' && d === '/') { state = 'code'; out += '  '; i += 2; continue }
+      out += c === '\n' ? '\n' : ' '; i++; continue
+    }
+    // sq | dq | tpl
+    if (c === '\\') { out += '  '; i += 2; continue }
+    const close = state === 'sq' ? "'" : state === 'dq' ? '"' : '`'
+    if (c === close) { state = 'code'; out += ' '; i++; continue }
+    out += c === '\n' ? '\n' : ' '; i++
+  }
+  return out
+}
+
+// Blank only comments (line + block), preserving string/template bodies + newlines.
+// Use when the token you match for lives INSIDE a string (e.g. revalidateTag('db')).
+export function stripComments(src) {
+  let out = ''
+  let state = 'code' // code | line | block | sq | dq | tpl
+  for (let i = 0; i < src.length; ) {
+    const c = src[i]
+    const d = src[i + 1]
+    if (state === 'code') {
+      if (c === '/' && d === '/') { state = 'line'; out += '  '; i += 2; continue }
+      if (c === '/' && d === '*') { state = 'block'; out += '  '; i += 2; continue }
+      if (c === "'") state = 'sq'
+      else if (c === '"') state = 'dq'
+      else if (c === '`') state = 'tpl'
+      out += c; i++; continue
+    }
+    if (state === 'line') {
+      if (c === '\n') { state = 'code'; out += '\n' } else out += ' '
+      i++; continue
+    }
+    if (state === 'block') {
+      if (c === '*' && d === '/') { state = 'code'; out += '  '; i += 2; continue }
+      out += c === '\n' ? '\n' : ' '; i++; continue
+    }
+    // inside a string: copy verbatim, honour escapes, exit on matching quote
+    if (c === '\\') { out += src[i] + (src[i + 1] ?? ''); i += 2; continue }
+    const close = state === 'sq' ? "'" : state === 'dq' ? '"' : '`'
+    if (c === close) state = 'code'
+    out += c; i++
+  }
+  return out
+}
+
+// Pretty-print a check result and return the process exit code.
+export function report(name, violations) {
+  if (violations.length === 0) {
+    console.log(`✓ ${name}: ok`)
+    return 0
+  }
+  console.log(`✗ ${name}: ${violations.length} violation(s)`)
+  for (const v of violations) console.log(`  - ${v}`)
+  return 1
+}

--- a/scripts/checks/consistency.mjs
+++ b/scripts/checks/consistency.mjs
@@ -1,0 +1,100 @@
+// LIVE data-integrity check (NOT in check:all — needs real creds).
+// Cross-checks the media/files tables against the actual Vercel Blob store, both
+// directions:
+//   - manifest -> blob: every blob a row references (original + thumb + the 4
+//     -1024/-1600 AVIF/WebP variants when variants=true) must exist in the store.
+//   - blob -> manifest: every media/ or files/ blob must be referenced by a row.
+// Trashed rows (deleted_at set) KEEP their blobs until purge, so BOTH directions
+// consider all rows regardless of deleted_at.
+//
+// Env from .env.local. Missing creds => warn + exit 0 (skip), so CI without
+// secrets never fails on it. A real mismatch => exit 1.
+import { existsSync, readFileSync } from 'node:fs'
+
+// Load .env.local without overwriting already-set vars.
+if (existsSync('.env.local')) {
+  for (const line of readFileSync('.env.local', 'utf8').split('\n')) {
+    const m = /^([A-Z0-9_]+)\s*=\s*(.*)$/.exec(line.trim())
+    if (m && process.env[m[1]] === undefined) {
+      process.env[m[1]] = m[2].replace(/^["']|["']$/g, '')
+    }
+  }
+}
+
+const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, BLOB_READ_WRITE_TOKEN } = process.env
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY || !BLOB_READ_WRITE_TOKEN) {
+  console.log('~ check:consistency:live SKIPPED — missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY / BLOB_READ_WRITE_TOKEN (.env.local).')
+  process.exit(0)
+}
+
+const { createClient } = await import('@supabase/supabase-js')
+const { list } = await import('@vercel/blob')
+
+const db = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  auth: { persistSession: false, autoRefreshToken: false },
+})
+
+const blobHostRe = /^https?:\/\/[a-z0-9-]+\.public\.blob\.vercel-storage\.com\//i
+const toPathname = (url) => url.replace(blobHostRe, '')
+// Global host strip (for free-text JSON, not just a single URL).
+const collapseHost = (s) => s.replace(/https?:\/\/[a-z0-9-]+\.public\.blob\.vercel-storage\.com\//gi, '')
+const variantNames = (path) => {
+  const stem = path.replace(/\.[^.]+$/, '')
+  return [`${stem}-1024.avif`, `${stem}-1600.avif`, `${stem}-1024.webp`, `${stem}-1600.webp`]
+}
+
+// 1. Every blob a row references (all rows; trashed keep their blobs).
+// The files/ prefix also holds non-table blobs: site icons (favicon-/app-icon-),
+// the rendered logo, and the custom font — all referenced from the settings JSON,
+// not the files table. So settings is part of the "referenced" source too.
+const { data: media, error: mErr } = await db.from('media').select('path, thumb, variants')
+const { data: files, error: fErr } = await db.from('files').select('url')
+const { data: settings, error: sErr } = await db.from('settings').select('data').eq('id', 1).maybeSingle()
+if (mErr || fErr || sErr) {
+  console.log(`✗ check:consistency:live: DB read failed — ${(mErr || fErr || sErr).message}`)
+  process.exit(1)
+}
+
+const referenced = new Set()
+for (const m of media ?? []) {
+  referenced.add(m.path)
+  if (m.thumb) referenced.add(m.thumb)
+  if (m.variants) for (const v of variantNames(m.path)) referenced.add(v)
+}
+for (const f of files ?? []) referenced.add(toPathname(f.url))
+// Pull every media/ + files/ pathname mentioned anywhere in the settings JSON
+// (icons, logo, custom font, OG images). Collapse any absolute URLs to pathnames first.
+const settingsJson = collapseHost(JSON.stringify(settings?.data ?? {}))
+for (const m of settingsJson.matchAll(/\b(?:media|files)\/[A-Za-z0-9._-]+/g)) referenced.add(m[0])
+
+// 2. Every blob actually in the store.
+const present = new Set()
+let cursor
+do {
+  const res = await list({ cursor, limit: 1000 })
+  for (const b of res.blobs) present.add(b.pathname)
+  cursor = res.cursor
+} while (cursor)
+
+// 3. Compare both directions.
+const violations = []
+for (const path of referenced) {
+  if (!present.has(path)) violations.push(`manifest -> blob MISSING: ${path}`)
+}
+for (const path of present) {
+  if ((path.startsWith('media/') || path.startsWith('files/')) && !referenced.has(path)) {
+    violations.push(`blob -> manifest ORPHAN: ${path}`)
+  }
+}
+
+console.log(
+  `  ${media?.length ?? 0} media + ${files?.length ?? 0} files rows; ` +
+    `${referenced.size} referenced blobs vs ${present.size} in store`,
+)
+if (violations.length === 0) {
+  console.log('✓ check:consistency:live: ok')
+  process.exit(0)
+}
+console.log(`✗ check:consistency:live: ${violations.length} mismatch(es)`)
+for (const v of violations) console.log(`  - ${v}`)
+process.exit(1)

--- a/scripts/checks/file-size.mjs
+++ b/scripts/checks/file-size.mjs
@@ -1,0 +1,31 @@
+// Convention: max 400 lines per source file (keeps modules thin + reviewable).
+// Scans every .ts/.tsx under src (incl. tests). Prints offenders longest-first.
+//
+// EXEMPT: pure type-declaration files (`*.d.ts`, `**/types.ts`). The 400-line cap
+// targets LOGIC files (code to reason about); a type manifest is one cohesive unit
+// with no logic and grows by design as UI strings are added. Exempting by KIND is
+// cleaner + zero-maintenance vs. a per-line marker.
+import { readFileSync } from 'node:fs'
+import { walk, isTs, lineCount, report } from './_util.mjs'
+
+const LIMIT = 400
+const isTypeDecl = (p) => /\.d\.ts$/.test(p) || /(?:^|\/)types\.ts$/.test(p)
+
+const all = walk('src', isTs)
+const files = all.filter((p) => !isTypeDecl(p))
+const exempt = all.filter(isTypeDecl)
+const violations = []
+for (const file of files) {
+  const n = lineCount(readFileSync(file, 'utf8'))
+  if (n > LIMIT) violations.push({ file, n })
+}
+violations.sort((a, b) => b.n - a.n)
+
+console.log(`  scanned ${files.length} src files (limit ${LIMIT} lines); ` +
+  `exempt: ${exempt.length} type declaration(s) [${exempt.join(', ')}]`)
+process.exit(
+  report(
+    'check:filesize',
+    violations.map((v) => `${v.file} — ${v.n} lines (over by ${v.n - LIMIT})`),
+  ),
+)

--- a/scripts/checks/no-any.mjs
+++ b/scripts/checks/no-any.mjs
@@ -1,0 +1,43 @@
+// Code-hygiene gate (audit §4): no `any` types, no stray console.log, no
+// TODO/FIXME, no @ts-ignore in src. `any`/console.log are matched on code with
+// comments + strings stripped (so a comment mentioning "any" is fine); the marker
+// comments are matched on raw text.
+//
+// Escape hatch for a SANCTIONED console.log: put `// check:allow-console` on the
+// same line. It stays greppable + auditable; every unmarked console.log fails.
+import { readFileSync } from 'node:fs'
+import { walk, isTs, stripCommentsAndStrings, report } from './_util.mjs'
+
+// `any` used as a type (not the substring of another word).
+const ANY_PATTERNS = [
+  /\bas\s+any\b/,
+  /:\s*any\b/,
+  /<\s*any\s*[,>]/,
+  /,\s*any\s*[,>]/,
+  /\bany\s*\[\]/,
+  /\|\s*any\b/,
+  /\bany\s*\|/,
+]
+
+const files = walk('src', isTs)
+const violations = []
+
+for (const file of files) {
+  const raw = readFileSync(file, 'utf8')
+  const code = stripCommentsAndStrings(raw)
+  const rawLines = raw.split('\n')
+  const codeLines = code.split('\n')
+  for (let i = 0; i < codeLines.length; i++) {
+    const codeLine = codeLines[i]
+    const rawLine = rawLines[i] ?? ''
+    const at = `${file}:${i + 1}`
+    if (ANY_PATTERNS.some((re) => re.test(codeLine))) violations.push(`${at} — 'any' type`)
+    if (/\bconsole\.log\s*\(/.test(codeLine) && !rawLine.includes('check:allow-console'))
+      violations.push(`${at} — console.log`)
+    if (/\b(TODO|FIXME)\b/.test(rawLine)) violations.push(`${at} — ${rawLine.match(/\b(TODO|FIXME)\b/)[1]}`)
+    if (/@ts-ignore\b/.test(rawLine)) violations.push(`${at} — @ts-ignore`)
+  }
+}
+
+console.log(`  scanned ${files.length} src files`)
+process.exit(report('check:no-any', violations))

--- a/scripts/checks/routes-guarded.mjs
+++ b/scripts/checks/routes-guarded.mjs
@@ -1,0 +1,50 @@
+// Invariant 4: every write/delete + owner-only API route calls requireOwner().
+// The ONLY routes allowed to skip it are the intentionally-public / self-authed
+// ones — and that set is the SINGLE source of truth in src/middleware.ts
+// (isPublicApi). This check mirrors that allowlist; if you add a public route,
+// add it there (and the middleware) — not by deleting the guard.
+//
+// NOTE: this is a static string-presence check (same semantics as the manual
+// `grep -L requireOwner`), not dataflow — a route that imports requireOwner for
+// another purpose still passes. Pair it with the middleware net + code review.
+import { readFileSync } from 'node:fs'
+import { walk, report } from './_util.mjs'
+
+const API_DIR = 'src/app/api'
+
+// Mirror of middleware.ts isPublicApi(). Keep in sync with that file.
+function isPublicApi(pathname) {
+  if (pathname.startsWith('/api/mcp/tokens')) return false
+  return (
+    pathname.startsWith('/api/auth') ||
+    pathname.startsWith('/api/cron') ||
+    pathname.startsWith('/api/track') ||
+    pathname.startsWith('/api/search') ||
+    pathname.startsWith('/api/mcp')
+  )
+}
+
+// src/app/api/posts/[slug]/route.ts -> /api/posts/[slug]
+const toApiPath = (file) => '/' + file.replace(/^src\/app\//, '').replace(/\/route\.ts$/, '')
+
+const routes = walk(API_DIR, (p) => p.endsWith('route.ts'))
+const violations = []
+let guarded = 0
+const exempt = []
+
+for (const file of routes) {
+  const apiPath = toApiPath(file)
+  const hasGuard = /\brequireOwner\s*\(/.test(readFileSync(file, 'utf8'))
+  if (isPublicApi(apiPath)) {
+    exempt.push(apiPath)
+    continue
+  }
+  if (hasGuard) guarded++
+  else violations.push(`${apiPath} (${file}) — owner-only route without requireOwner()`)
+}
+
+console.log(
+  `  scanned ${routes.length} routes: ${guarded} owner-gated, ${exempt.length} public-exempt ` +
+    `(${exempt.sort().join(', ')})`,
+)
+process.exit(report('check:routes', violations))

--- a/scripts/checks/token-no-public-bust.mjs
+++ b/scripts/checks/token-no-public-bust.mjs
@@ -1,0 +1,34 @@
+// Implicit invariant (asymmetric cache-bust policy):
+//   - MCP token CRUD routes must NEVER bust the public 'db' tag. They are
+//     force-no-store, so an admin read is live; calling revalidateTag('db') here
+//     would OVER-PURGE every public page on a token mint/delete. The regression
+//     risk lives at the CALL SITE (the token route), not in revalidate.ts — so a
+//     unit test on revalidate.ts can't catch it. This is the precise negative check.
+//   - SYMMETRIC (coarse tripwire): backup-state.ts must STILL wire the DB bust
+//     (its writes are out-of-band and DO need revalidateTag(DB_TAG)). This only
+//     catches wholesale removal — per-write-function coverage is review-enforced
+//     (see CLAUDE.md invariant #2).
+import { readFileSync } from 'node:fs'
+import { walk, stripComments, report } from './_util.mjs'
+
+const BUST_DB = /revalidateTag\s*\(\s*(?:DB_TAG|['"]db['"])/
+
+const violations = []
+
+// 1. Negative: no token route may bust 'db'.
+const tokenRoutes = walk('src/app/api/mcp/tokens', (p) => p.endsWith('route.ts'))
+for (const file of tokenRoutes) {
+  const code = stripComments(readFileSync(file, 'utf8'))
+  if (BUST_DB.test(code)) {
+    violations.push(`${file} — token route MUST NOT revalidateTag('db') (over-purges public; relies on force-no-store)`)
+  }
+}
+
+// 2. Positive tripwire: backup-state.ts must still bust 'db' somewhere.
+const BACKUP_STATE = 'src/lib/backup-state.ts'
+if (!BUST_DB.test(stripComments(readFileSync(BACKUP_STATE, 'utf8')))) {
+  violations.push(`${BACKUP_STATE} — out-of-band writes lost their revalidateTag(DB_TAG) bust wiring`)
+}
+
+console.log(`  scanned ${tokenRoutes.length} token route(s) + backup-state.ts`)
+process.exit(report('check:token-bust', violations))

--- a/scripts/legacy/README.md
+++ b/scripts/legacy/README.md
@@ -1,0 +1,1 @@
+Pre-Supabase relics. Do NOT run, do NOT reference when fixing current code.

--- a/src/components/blog/post-content.test.ts
+++ b/src/components/blog/post-content.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { PostContent } from './PostContent'
+import { extractHeadings } from '@/lib/utils'
+
+// PostContent is a plain async server component: call it as a function and read
+// the HTML it emits via dangerouslySetInnerHTML. Markdown WITHOUT code fences so
+// Shiki never runs -> the test stays offline + fast.
+async function render(markdown: string): Promise<string> {
+  const el = await PostContent({ markdown })
+  const props = (el as unknown as { props: { dangerouslySetInnerHTML?: { __html: string } } }).props
+  return props.dangerouslySetInnerHTML?.__html ?? ''
+}
+
+describe('markdown render — security', () => {
+  it('escapes raw HTML instead of executing it (<script> shown as text)', async () => {
+    const html = await render('<script>alert(1)</script>')
+    expect(html).toContain('&lt;script&gt;')
+    expect(html).not.toContain('<script>')
+  })
+
+  it('renders an onerror <img> inert (escaped), not a live tag', async () => {
+    const html = await render('<img src=x onerror=alert(1)>')
+    expect(html).toContain('&lt;img')
+    expect(html).not.toMatch(/<img[^>]*onerror/)
+  })
+
+  it('neutralizes a javascript: link href to #', async () => {
+    const html = await render('[click me](javascript:alert(1))')
+    expect(html).toContain('href="#"')
+    expect(html).not.toContain('javascript:')
+  })
+})
+
+describe('markdown render — structure', () => {
+  it('gives H2 and H3 slug ids but leaves H1 without one', async () => {
+    const html = await render('## Hello World\n\n### Sub Section\n\n# Big Title')
+    expect(html).toContain('<h2 id="hello-world">')
+    expect(html).toContain('<h3 id="sub-section">')
+    expect(html).toContain('<h1>Big Title</h1>')
+  })
+
+  it('de-dupes ids for duplicate headings (foo, foo-2)', async () => {
+    const html = await render('## Repeat\n\n## Repeat')
+    expect(html).toContain('id="repeat"')
+    expect(html).toContain('id="repeat-2"')
+  })
+
+  it('turns a standalone YouTube URL into a responsive iframe embed', async () => {
+    const html = await render('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+    expect(html).toContain('<div class="video-embed">')
+    expect(html).toContain('youtube-nocookie.com/embed/dQw4w9WgXcQ')
+  })
+
+  it('wraps a markdown image in a <figure> with the alt as <figcaption>', async () => {
+    const html = await render('![A small cat](media/cat.jpg)')
+    expect(html).toContain('<figure')
+    expect(html).toContain('<figcaption>A small cat</figcaption>')
+  })
+})
+
+describe('markdown render — ToC anchors stay in sync', () => {
+  it('PostContent ids match extractHeadings ids on duplicate headings', async () => {
+    const md = '## Foo\n\nbody\n\n## Foo\n\n### Bar'
+    const html = await render(md)
+    const renderedIds = [...html.matchAll(/<h[23] id="([^"]+)"/g)].map((m) => m[1])
+    const tocIds = extractHeadings(md).map((h) => h.id)
+    expect(renderedIds).toEqual(tocIds)
+    expect(renderedIds).toEqual(['foo', 'foo-2', 'bar'])
+  })
+})

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -15,7 +15,7 @@ export function fail(error: string, status = 400): Response {
 // Standard request/response log line.
 export function logRequest(req: NextRequest, status: number, start: number): void {
   const { pathname } = new URL(req.url)
-  console.log(`[${req.method}] ${pathname} — ${status} — ${Date.now() - start}ms`)
+  console.log(`[${req.method}] ${pathname} — ${status} — ${Date.now() - start}ms`) // check:allow-console -- intentional request access log
 }
 
 // Standard error log line.

--- a/src/lib/blob.test.ts
+++ b/src/lib/blob.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { blobUrl, collapseBlob, expandBlob } from '@/lib/blob'
+
+// The fake token in vitest.config.ts derives this deterministic store host.
+const HOST = 'https://teststore.public.blob.vercel-storage.com'
+
+describe('blob store-relative refs (collapse <-> expand)', () => {
+  it('expands a media pathname into an absolute store URL', () => {
+    expect(expandBlob('media/photo.jpg')).toBe(`${HOST}/media/photo.jpg`)
+  })
+
+  it('expands a files pathname (favicon / app icon) too', () => {
+    expect(expandBlob('files/favicon-123.ico')).toBe(`${HOST}/files/favicon-123.ico`)
+  })
+
+  it('collapses an absolute store URL back to a store-relative pathname', () => {
+    expect(collapseBlob(`${HOST}/media/photo.jpg`)).toBe('media/photo.jpg')
+  })
+
+  it('round-trips a bare pathname (collapse after expand is identity)', () => {
+    const pathname = 'media/nested/dir/image-1600.avif'
+    expect(collapseBlob(expandBlob(pathname))).toBe(pathname)
+  })
+
+  it('round-trips an absolute URL (expand after collapse is identity)', () => {
+    const url = `${HOST}/media/photo.png`
+    expect(expandBlob(collapseBlob(url))).toBe(url)
+  })
+
+  it('is idempotent: collapsing an already store-relative string changes nothing', () => {
+    expect(collapseBlob('media/photo.jpg')).toBe('media/photo.jpg')
+  })
+
+  it('leaves external (non-blob) URLs untouched on expand', () => {
+    const external = 'https://example.com/img/banner.jpg'
+    expect(expandBlob(external)).toBe(external)
+    expect(collapseBlob(external)).toBe(external)
+  })
+
+  it('stores a markdown body with NO storeId/host after collapse', () => {
+    const body = `Look: ![alt](${HOST}/media/a.jpg) and <img src="${HOST}/media/b.png">`
+    const stored = collapseBlob(body)
+    expect(stored).not.toContain('teststore')
+    expect(stored).not.toContain('public.blob.vercel-storage.com')
+    expect(stored).toContain('](media/a.jpg)')
+    expect(stored).toContain('src="media/b.png"')
+  })
+
+  it('expands media refs inside markdown link/src/href positions only', () => {
+    const body = 'text media/loose.jpg ![x](media/a.jpg) <img src="media/b.png">'
+    const out = expandBlob(body)
+    // link + src positions are rewritten...
+    expect(out).toContain(`](${HOST}/media/a.jpg)`)
+    expect(out).toContain(`src="${HOST}/media/b.png"`)
+    // ...but a loose mention mid-paragraph is NOT (only positional refs expand).
+    expect(out).toContain('text media/loose.jpg ')
+  })
+
+  it('blobUrl builds the deterministic public URL from the token', () => {
+    expect(blobUrl('media/x.webp')).toBe(`${HOST}/media/x.webp`)
+  })
+})

--- a/src/lib/i18n.test.ts
+++ b/src/lib/i18n.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { t, formatDate } from '@/lib/i18n'
+import en from '@/locales/en'
+import type { SiteLang } from '@/types'
+
+describe('t (locale lookup)', () => {
+  it('returns the requested locale dictionary', () => {
+    expect(t('vi')).not.toBe(en)
+  })
+
+  it('falls back to English for an unknown language', () => {
+    expect(t('xx' as SiteLang)).toBe(en)
+  })
+})
+
+describe('formatDate', () => {
+  it('uses the explicit Vietnamese long form', () => {
+    expect(formatDate('2026-06-19', 'vi')).toBe('19 tháng 6, 2026')
+  })
+
+  it('returns the raw input for an unparseable date', () => {
+    expect(formatDate('not-a-date', 'en')).toBe('not-a-date')
+  })
+})

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -1,0 +1,51 @@
+// Image encoding — pure sharp pipeline (Buffer -> Buffer / dimensions). No DB, no
+// Blob, no app state. media.ts depends on this ONE WAY (media -> image, never back).
+
+import sharp from 'sharp'
+
+export const RASTER = /^image\/(jpeg|png)$/ // full responsive pipeline
+export const PASSTHROUGH = /^image\/(svg\+xml|gif|webp)$/ // stored as-is, no variants
+export const SIZES = [1024, 1600] as const // display widths (in-column / wider)
+const THUMB_WIDTH = 400
+
+export type Variant = { suffix: string; data: Buffer; contentType: string }
+
+// From the original bytes, read pixel dimensions (auto-oriented).
+export async function imageSize(original: Buffer): Promise<{ width: number; height: number }> {
+  const meta = await sharp(original, { failOn: 'none' }).rotate().metadata()
+  return { width: meta.width ?? 0, height: meta.height ?? 0 }
+}
+
+// Pixel dimensions for any image we can decode (raster + webp/gif, and most svg).
+export async function safeSize(buf: Buffer): Promise<{ width?: number; height?: number }> {
+  try {
+    const { width, height } = await imageSize(buf)
+    return width && height ? { width, height } : {}
+  } catch {
+    return {}
+  }
+}
+
+// Small library thumbnail — cheap, made on upload so the grid renders at once.
+export async function makeThumb(original: Buffer): Promise<Buffer> {
+  return sharp(original, { failOn: 'none' })
+    .rotate()
+    .resize({ width: THUMB_WIDTH, withoutEnlargement: true })
+    .webp({ quality: 70 })
+    .toBuffer()
+}
+
+// The heavy display set (AVIF + WebP @ each size) — deferred to AFTER save so the
+// save request never blocks on the AVIF encode (the original always renders).
+export async function makeDisplay(original: Buffer): Promise<Variant[]> {
+  const { width: ow } = await imageSize(original)
+  const files: Variant[] = []
+  for (const w of SIZES) {
+    const pipe = sharp(original, { failOn: 'none' })
+      .rotate()
+      .resize({ width: ow ? Math.min(w, ow) : w, withoutEnlargement: true })
+    files.push({ suffix: `-${w}.webp`, data: await pipe.clone().webp({ quality: 80 }).toBuffer(), contentType: 'image/webp' })
+    files.push({ suffix: `-${w}.avif`, data: await pipe.clone().avif({ quality: 50 }).toBuffer(), contentType: 'image/avif' })
+  }
+  return files
+}

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -3,7 +3,6 @@
 // -thumb.webp. Vector/anim (svg/gif/webp) stored as-is. Variant URLs derived by
 // convention from the original's name.
 
-import sharp from 'sharp'
 import { cache } from 'react'
 import type { MediaItem } from '@/types'
 import {
@@ -11,11 +10,9 @@ import {
 } from '@/lib/blob'
 import { db } from '@/lib/db'
 import { slugify } from '@/lib/utils'
-
-const RASTER = /^image\/(jpeg|png)$/ // full responsive pipeline
-const PASSTHROUGH = /^image\/(svg\+xml|gif|webp)$/ // stored as-is, no variants
-const SIZES = [1024, 1600] as const // display widths (in-column / wider)
-const THUMB_WIDTH = 400
+import {
+  imageSize, safeSize, makeThumb, makeDisplay, RASTER, PASSTHROUGH, SIZES,
+} from '@/lib/image'
 
 // A row as stored in Postgres (store-relative paths).
 type MediaRow = {
@@ -68,48 +65,6 @@ async function listMedia(): Promise<MediaItem[]> {
 // Library list, newest first. `React.cache` dedupes within one render; each
 // request re-reads Postgres so the library is always fresh.
 export const getMedia = cache(listMedia)
-
-type Variant = { suffix: string; data: Buffer; contentType: string }
-
-// From the original bytes, read pixel dimensions (auto-oriented).
-async function imageSize(original: Buffer): Promise<{ width: number; height: number }> {
-  const meta = await sharp(original, { failOn: 'none' }).rotate().metadata()
-  return { width: meta.width ?? 0, height: meta.height ?? 0 }
-}
-
-// Pixel dimensions for any image we can decode (raster + webp/gif, and most svg).
-async function safeSize(buf: Buffer): Promise<{ width?: number; height?: number }> {
-  try {
-    const { width, height } = await imageSize(buf)
-    return width && height ? { width, height } : {}
-  } catch {
-    return {}
-  }
-}
-
-// Small library thumbnail — cheap, made on upload so the grid renders at once.
-async function makeThumb(original: Buffer): Promise<Buffer> {
-  return sharp(original, { failOn: 'none' })
-    .rotate()
-    .resize({ width: THUMB_WIDTH, withoutEnlargement: true })
-    .webp({ quality: 70 })
-    .toBuffer()
-}
-
-// The heavy display set (AVIF + WebP @ each size) — deferred to AFTER save so the
-// save request never blocks on the AVIF encode (the original always renders).
-async function makeDisplay(original: Buffer): Promise<Variant[]> {
-  const { width: ow } = await imageSize(original)
-  const files: Variant[] = []
-  for (const w of SIZES) {
-    const pipe = sharp(original, { failOn: 'none' })
-      .rotate()
-      .resize({ width: ow ? Math.min(w, ow) : w, withoutEnlargement: true })
-    files.push({ suffix: `-${w}.webp`, data: await pipe.clone().webp({ quality: 80 }).toBuffer(), contentType: 'image/webp' })
-    files.push({ suffix: `-${w}.avif`, data: await pipe.clone().avif({ quality: 50 }).toBuffer(), contentType: 'image/avif' })
-  }
-  return files
-}
 
 // All taken media pathnames, for collision-free naming. Unions DB rows with
 // ACTUAL store contents (listBlobs) so derived thumb/variant names are covered too.

--- a/src/lib/paginate.test.ts
+++ b/src/lib/paginate.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { parsePathPage, paginate } from '@/lib/paginate'
+
+describe('parsePathPage', () => {
+  it('returns null for "1" (page 1 lives at the bare path, no dup URL)', () => {
+    expect(parsePathPage('1')).toBeNull()
+  })
+
+  it('returns the number for a real deep page (>= 2)', () => {
+    expect(parsePathPage('3')).toBe(3)
+  })
+
+  it('returns null for non-numeric junk', () => {
+    expect(parsePathPage('abc')).toBeNull()
+    expect(parsePathPage('2x')).toBeNull()
+  })
+})
+
+describe('paginate', () => {
+  const all = [1, 2, 3, 4, 5, 6, 7]
+
+  it('slices the requested page and reports total pages', () => {
+    expect(paginate(all, 2, 3)).toEqual({ items: [4, 5, 6], page: 2, totalPages: 3 })
+  })
+
+  it('clamps an out-of-range page into the valid range', () => {
+    expect(paginate(all, 99, 3).page).toBe(3)
+    expect(paginate(all, 0, 3).page).toBe(1)
+  })
+
+  it('always reports at least 1 page for an empty list', () => {
+    expect(paginate([], 1, 3)).toEqual({ items: [], page: 1, totalPages: 1 })
+  })
+})

--- a/src/lib/revalidate.test.ts
+++ b/src/lib/revalidate.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the Next cache boundary — these throw outside a request scope and are the
+// exact seam we want to observe (which paths/tags each purge emits).
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}))
+
+import { revalidatePath, revalidateTag } from 'next/cache'
+import {
+  revalidateNewPost,
+  revalidatePost,
+  revalidatePage,
+  revalidateEverything,
+} from '@/lib/revalidate'
+
+const paths = () => vi.mocked(revalidatePath).mock.calls
+// All list/taxonomy/feed surfaces a post change must refresh (the SUPERSET).
+const LIST_SURFACES: Array<[string, string?]> = [
+  ['/'],
+  ['/page/[n]', 'page'],
+  ['/category/[slug]', 'page'],
+  ['/category/[slug]/page/[n]', 'page'],
+  ['/tag/[slug]', 'page'],
+  ['/tag/[slug]/page/[n]', 'page'],
+  ['/feed.xml'],
+  ['/sitemap.xml'],
+  ['/llms.txt'],
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('revalidate is a SUPERSET of the affected surfaces', () => {
+  it('freshens the DB tag before any path purge (revalidateTag db, max)', () => {
+    revalidateNewPost()
+    expect(revalidateTag).toHaveBeenCalledWith('db', 'max')
+  })
+
+  it('a new post purges every list/taxonomy/feed surface', () => {
+    revalidateNewPost()
+    for (const surface of LIST_SURFACES) {
+      expect(revalidatePath).toHaveBeenCalledWith(...surface)
+    }
+  })
+
+  it('editing a post purges its own /slug AND all list surfaces', () => {
+    revalidatePost('my-post')
+    expect(revalidatePath).toHaveBeenCalledWith('/my-post')
+    for (const surface of LIST_SURFACES) {
+      expect(revalidatePath).toHaveBeenCalledWith(...surface)
+    }
+  })
+
+  it('renaming a post purges BOTH the old and new slug paths', () => {
+    revalidatePost('new-slug', 'old-slug')
+    expect(revalidatePath).toHaveBeenCalledWith('/new-slug')
+    expect(revalidatePath).toHaveBeenCalledWith('/old-slug')
+  })
+
+  it('does not re-purge the old slug when it equals the new slug', () => {
+    revalidatePost('same', 'same')
+    const slugCalls = paths().filter((c) => c[0] === '/same')
+    expect(slugCalls).toHaveLength(1)
+  })
+
+  it('a page purges only its own URL + sitemap + llms, not the post lists', () => {
+    revalidatePage('about')
+    expect(revalidatePath).toHaveBeenCalledWith('/about')
+    expect(revalidatePath).toHaveBeenCalledWith('/sitemap.xml')
+    expect(revalidatePath).toHaveBeenCalledWith('/llms.txt')
+    // A page is standalone — it must NOT churn the home/taxonomy list surfaces.
+    expect(revalidatePath).not.toHaveBeenCalledWith('/')
+    expect(revalidatePath).not.toHaveBeenCalledWith('/category/[slug]', 'page')
+    expect(revalidatePath).not.toHaveBeenCalledWith('/feed.xml')
+  })
+
+  it('a settings change purges the whole site under the root layout', () => {
+    revalidateEverything()
+    expect(revalidatePath).toHaveBeenCalledWith('/', 'layout')
+    expect(revalidateTag).toHaveBeenCalledWith('db', 'max')
+  })
+})

--- a/src/lib/settings-sanitize.ts
+++ b/src/lib/settings-sanitize.ts
@@ -1,0 +1,218 @@
+// Settings validation + migration — pure functions (unknown -> typed, clamped,
+// back-compat shims). No DB, no Blob, no React. settings.ts depends on this ONE
+// WAY (settings -> settings-sanitize, never back) for its getSettings/saveSettings merge.
+
+import type { BackupSettings, FeatureSettings, FontFace, FontSettings, McpSettings, MenuItem, SeoSettings, ThemeColors, ThemeSettings, TypeStyle, TypographySettings } from '@/types'
+import { DEFAULT_PRESET_ID, isPresetId, defaultThemes, THEME_PRESETS, DEFAULT_FONT, TYPE_ROLES, FONT_WEIGHTS } from '@/lib/themes'
+
+// Keep only well-formed menu items (label + href both present).
+export function sanitizeMenu(input: unknown, fallback: MenuItem[]): MenuItem[] {
+  if (!Array.isArray(input)) return fallback
+  return input
+    .filter((m): m is MenuItem => !!m && typeof m.label === 'string' && typeof m.href === 'string')
+    .map((m) => ({ label: m.label.trim(), href: m.href.trim() }))
+    .filter((m) => m.label && m.href)
+}
+
+const HEX = /^#[0-9a-fA-F]{3,8}$/
+
+// Validate one color, falling back when malformed.
+function color(value: unknown, fallback: string): string {
+  return typeof value === 'string' && HEX.test(value.trim()) ? value.trim() : fallback
+}
+
+// Merge a partial color set over a fallback set.
+function sanitizeColors(input: unknown, fallback: ThemeColors): ThemeColors {
+  const o = (input ?? {}) as Partial<ThemeColors>
+  return {
+    bg: color(o.bg, fallback.bg),
+    text: color(o.text, fallback.text),
+    heading: color(o.heading, fallback.heading),
+    meta: color(o.meta, fallback.meta),
+    link: color(o.link, fallback.link),
+    rule: color(o.rule, fallback.rule),
+  }
+}
+
+function sanitizeTheme(input: unknown, fallback: ThemeSettings): ThemeSettings {
+  const o = (input ?? {}) as Partial<ThemeSettings>
+  return {
+    light: sanitizeColors(o.light, fallback.light),
+    dark: sanitizeColors(o.dark, fallback.dark),
+  }
+}
+
+// Back-compat: older configs stored a single `theme`; seed it into the default
+// palette so custom colors survive the move to per-palette.
+export function migrateThemes(stored: Record<string, unknown>): Record<string, ThemeSettings> {
+  const base = defaultThemes()
+  const legacy = stored.theme
+  if (stored.themes == null && legacy) {
+    const def = isPresetId(stored.themePreset) ? (stored.themePreset as string) : DEFAULT_PRESET_ID
+    base[def] = sanitizeTheme(legacy, base[def])
+  }
+  return base
+}
+
+// Per-palette map: merge stored colors over `base` for each known preset id;
+// unknown ids dropped.
+export function sanitizeThemes(input: unknown, base: Record<string, ThemeSettings>): Record<string, ThemeSettings> {
+  const o = (input ?? {}) as Record<string, unknown>
+  const out: Record<string, ThemeSettings> = {}
+  for (const p of THEME_PRESETS) {
+    out[p.id] = sanitizeTheme(o[p.id], base[p.id] ?? p.theme)
+  }
+  return out
+}
+
+const bool = (v: unknown, fallback: boolean): boolean => (typeof v === 'boolean' ? v : fallback)
+
+export function sanitizeSeo(input: unknown, fallback: SeoSettings): SeoSettings {
+  const o = (input ?? {}) as Partial<SeoSettings>
+  return {
+    autoSchema: bool(o.autoSchema, fallback.autoSchema),
+    sitemap: bool(o.sitemap, fallback.sitemap),
+    llms: bool(o.llms, fallback.llms),
+    robots: bool(o.robots, fallback.robots),
+    rss: bool(o.rss, fallback.rss),
+    ogImage: bool(o.ogImage, fallback.ogImage),
+    // A full image URL (keep the path); only the type is validated.
+    ogFallbackImage: typeof o.ogFallbackImage === 'string' ? o.ogFallbackImage.trim() : fallback.ogFallbackImage,
+  }
+}
+
+export function sanitizeFeatures(input: unknown, fallback: FeatureSettings): FeatureSettings {
+  const o = (input ?? {}) as Partial<FeatureSettings>
+  return {
+    search: bool(o.search, fallback.search),
+    toc: bool(o.toc, fallback.toc),
+    related: bool(o.related, fallback.related),
+    readingTime: bool(o.readingTime, fallback.readingTime),
+    progressBar: bool(o.progressBar, fallback.progressBar),
+    activityLog: bool(o.activityLog, fallback.activityLog),
+  }
+}
+
+export function sanitizeMcp(input: unknown, fallback: McpSettings): McpSettings {
+  const o = (input ?? {}) as Partial<McpSettings>
+  return { enabled: bool(o.enabled, fallback.enabled) }
+}
+
+export function sanitizeBackups(input: unknown, fallback: BackupSettings): BackupSettings {
+  const o = (input ?? {}) as Partial<BackupSettings>
+  return {
+    enabled: bool(o.enabled, fallback.enabled),
+    intervalDays: clampNumber(o.intervalDays, 1, 30, fallback.intervalDays),
+    keep: clampNumber(o.keep, 1, 30, fallback.keep),
+  }
+}
+
+// Owner CSS injected raw into <style>. Owner-only, so the only hazard is an
+// accidental `</style>` closing the tag early — strip it; pass the rest through.
+export function sanitizeCss(value: unknown): string {
+  return typeof value === 'string' ? value.replace(/<\/style/gi, '') : ''
+}
+
+// Accept only a valid http(s) URL with no trailing slash; '' otherwise.
+export function sanitizeUrl(value: unknown): string {
+  if (typeof value !== 'string' || !value.trim()) return ''
+  try {
+    const u = new URL(value.trim())
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return ''
+    return u.origin
+  } catch {
+    return ''
+  }
+}
+
+// Clamp a float into [min,max], keeping up to 2 decimals; fall back when invalid.
+function clampFloat(value: unknown, min: number, max: number, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  return Math.min(max, Math.max(min, Math.round(value * 100) / 100))
+}
+
+// One role's style, clamped. size rem [0.5,6]; line [0.8,3]; spacing em [-0.2,0.5].
+function sanitizeStyle(input: unknown, fallback: TypeStyle): TypeStyle {
+  const o = (input ?? {}) as Partial<TypeStyle>
+  return {
+    size: clampFloat(o.size, 0.5, 6, fallback.size),
+    line: clampFloat(o.line, 0.8, 3, fallback.line),
+    spacing: clampFloat(o.spacing, -0.2, 0.5, fallback.spacing),
+  }
+}
+
+// Back-compat: the first typography shape was flat ({ base, h1..h5, lineHeight,
+// letterSpacing }); lift those into the role map so an early save survives.
+function migrateTypography(o: Record<string, unknown>, base: TypographySettings): TypographySettings {
+  if (o.roles || typeof o.base !== 'number') return base
+  const num = (v: unknown, f: number) => (typeof v === 'number' && Number.isFinite(v) ? v : f)
+  const line = num(o.lineHeight, base.roles.body.line)
+  const sp = num(o.letterSpacing, base.roles.body.spacing)
+  const r = base.roles
+  return {
+    roles: {
+      ...r,
+      body: { size: num(o.base, r.body.size), line, spacing: sp },
+      h1: { ...r.h1, size: num(o.h1, r.h1.size) },
+      h2: { ...r.h2, size: num(o.h2, r.h2.size) },
+      h3: { ...r.h3, size: num(o.h3, r.h3.size) },
+      h4: { ...r.h4, size: num(o.h4, r.h4.size) },
+      h5: { ...r.h5, size: num(o.h5, r.h5.size) },
+    },
+    smoothing: bool(o.smoothing, base.smoothing),
+  }
+}
+
+export function sanitizeTypography(input: unknown, fallback: TypographySettings): TypographySettings {
+  const o = (input ?? {}) as Record<string, unknown>
+  const base = migrateTypography(o, fallback)
+  const inRoles = (o.roles ?? {}) as Record<string, unknown>
+  const roles = {} as TypographySettings['roles']
+  for (const role of TYPE_ROLES) roles[role] = sanitizeStyle(inRoles[role], base.roles[role])
+  return { roles, smoothing: bool(o.smoothing, base.smoothing) }
+}
+
+// Family name -> safe CSS identifier (never trust raw into <style>): allow
+// letters/digits/space/hyphen, collapse the rest.
+function sanitizeFamily(value: unknown): string {
+  return typeof value === 'string' ? value.replace(/[^A-Za-z0-9 _-]/g, '').trim().slice(0, 64) : ''
+}
+
+// One uploaded weight: a known weight + a non-empty url. Maps the legacy single
+// `url` (no weight) to the 400 slot.
+function sanitizeFaces(input: unknown, legacyUrl: unknown): FontFace[] {
+  const raw = Array.isArray(input)
+    ? input
+    : typeof legacyUrl === 'string' && legacyUrl.trim()
+      ? [{ weight: 400, url: legacyUrl }]
+      : []
+  const byWeight = new Map<number, string>()
+  for (const f of raw) {
+    const o = (f ?? {}) as Partial<FontFace>
+    const w = typeof o.weight === 'number' ? o.weight : NaN
+    if (FONT_WEIGHTS.includes(w as (typeof FONT_WEIGHTS)[number]) && typeof o.url === 'string' && o.url.trim()) {
+      byWeight.set(w, o.url.trim())
+    }
+  }
+  return FONT_WEIGHTS.filter((w) => byWeight.has(w)).map((w) => ({ weight: w, url: byWeight.get(w)! }))
+}
+
+export function sanitizeFont(input: unknown, fallback: FontSettings): FontSettings {
+  const o = (input ?? {}) as Record<string, unknown>
+  const family = o.family !== undefined ? sanitizeFamily(o.family) : fallback.family
+  const faces = sanitizeFaces(o.faces, o.url)
+  // Need a family AND at least one face; otherwise "no custom font".
+  return family && faces.length ? { family, faces } : DEFAULT_FONT
+}
+
+// font URL -> @font-face `format(...)` hint, by extension. Unknown -> omit it.
+export function fontFormat(url: string): string {
+  const ext = url.split(/[?#]/)[0].split('.').pop()?.toLowerCase()
+  return ext === 'woff2' ? 'woff2' : ext === 'woff' ? 'woff' : ext === 'ttf' ? 'truetype' : ext === 'otf' ? 'opentype' : ''
+}
+
+// Clamp a possibly-invalid number into a range, falling back to a default.
+export function clampNumber(value: unknown, min: number, max: number, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  return Math.min(max, Math.max(min, Math.round(value)))
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,137 +1,21 @@
 // Settings: a single row (id=1) in Postgres `settings`. Reads fall back to
 // defaults on any failure so the header/<title> never crash. Image refs stored
-// store-relative, binaries on Blob.
+// store-relative, binaries on Blob. Validation/migration lives in settings-sanitize.ts.
 
 import { cache } from 'react'
-import type { BackupSettings, FeatureSettings, FontFace, FontSettings, McpSettings, MenuItem, SeoSettings, SiteSettings, ThemeColors, ThemeSettings, TypeStyle, TypographySettings } from '@/types'
+import type { BackupSettings, FeatureSettings, FontSettings, SeoSettings, SiteSettings, TypographySettings } from '@/types'
 import { collapseBlob, expandBlob, deleteByPathname } from '@/lib/blob'
 import { renderLogo } from '@/lib/files'
 import { db } from '@/lib/db'
 import { isSiteLang } from '@/locales/langs'
-import { DEFAULT_PRESET_ID, isPresetId, defaultThemes, THEME_PRESETS, DEFAULT_TYPOGRAPHY, DEFAULT_FONT, TYPE_ROLES, FONT_WEIGHTS } from '@/lib/themes'
+import { DEFAULT_PRESET_ID, isPresetId, defaultThemes, DEFAULT_TYPOGRAPHY, DEFAULT_FONT, TYPE_ROLES } from '@/lib/themes'
+import {
+  sanitizeMenu, migrateThemes, sanitizeThemes, sanitizeSeo, sanitizeFeatures, sanitizeMcp,
+  sanitizeBackups, sanitizeCss, sanitizeUrl, sanitizeTypography, sanitizeFont, fontFormat, clampNumber,
+} from '@/lib/settings-sanitize'
 
 // Re-export so existing importers keep working.
 export { DEFAULT_THEME, themesToCss, getDefaultTheme, DEFAULT_TYPOGRAPHY, DEFAULT_FONT } from '@/lib/themes'
-
-// Keep only well-formed menu items (label + href both present).
-function sanitizeMenu(input: unknown, fallback: MenuItem[]): MenuItem[] {
-  if (!Array.isArray(input)) return fallback
-  return input
-    .filter((m): m is MenuItem => !!m && typeof m.label === 'string' && typeof m.href === 'string')
-    .map((m) => ({ label: m.label.trim(), href: m.href.trim() }))
-    .filter((m) => m.label && m.href)
-}
-
-const HEX = /^#[0-9a-fA-F]{3,8}$/
-
-// Validate one color, falling back when malformed.
-function color(value: unknown, fallback: string): string {
-  return typeof value === 'string' && HEX.test(value.trim()) ? value.trim() : fallback
-}
-
-// Merge a partial color set over a fallback set.
-function sanitizeColors(input: unknown, fallback: ThemeColors): ThemeColors {
-  const o = (input ?? {}) as Partial<ThemeColors>
-  return {
-    bg: color(o.bg, fallback.bg),
-    text: color(o.text, fallback.text),
-    heading: color(o.heading, fallback.heading),
-    meta: color(o.meta, fallback.meta),
-    link: color(o.link, fallback.link),
-    rule: color(o.rule, fallback.rule),
-  }
-}
-
-function sanitizeTheme(input: unknown, fallback: ThemeSettings): ThemeSettings {
-  const o = (input ?? {}) as Partial<ThemeSettings>
-  return {
-    light: sanitizeColors(o.light, fallback.light),
-    dark: sanitizeColors(o.dark, fallback.dark),
-  }
-}
-
-// Back-compat: older configs stored a single `theme`; seed it into the default
-// palette so custom colors survive the move to per-palette.
-function migrateThemes(stored: Record<string, unknown>): Record<string, ThemeSettings> {
-  const base = defaultThemes()
-  const legacy = stored.theme
-  if (stored.themes == null && legacy) {
-    const def = isPresetId(stored.themePreset) ? (stored.themePreset as string) : DEFAULT_PRESET_ID
-    base[def] = sanitizeTheme(legacy, base[def])
-  }
-  return base
-}
-
-// Per-palette map: merge stored colors over `base` for each known preset id;
-// unknown ids dropped.
-function sanitizeThemes(input: unknown, base: Record<string, ThemeSettings>): Record<string, ThemeSettings> {
-  const o = (input ?? {}) as Record<string, unknown>
-  const out: Record<string, ThemeSettings> = {}
-  for (const p of THEME_PRESETS) {
-    out[p.id] = sanitizeTheme(o[p.id], base[p.id] ?? p.theme)
-  }
-  return out
-}
-
-const bool = (v: unknown, fallback: boolean): boolean => (typeof v === 'boolean' ? v : fallback)
-
-function sanitizeSeo(input: unknown, fallback: SeoSettings): SeoSettings {
-  const o = (input ?? {}) as Partial<SeoSettings>
-  return {
-    autoSchema: bool(o.autoSchema, fallback.autoSchema),
-    sitemap: bool(o.sitemap, fallback.sitemap),
-    llms: bool(o.llms, fallback.llms),
-    robots: bool(o.robots, fallback.robots),
-    rss: bool(o.rss, fallback.rss),
-    ogImage: bool(o.ogImage, fallback.ogImage),
-    // A full image URL (keep the path); only the type is validated.
-    ogFallbackImage: typeof o.ogFallbackImage === 'string' ? o.ogFallbackImage.trim() : fallback.ogFallbackImage,
-  }
-}
-
-function sanitizeFeatures(input: unknown, fallback: FeatureSettings): FeatureSettings {
-  const o = (input ?? {}) as Partial<FeatureSettings>
-  return {
-    search: bool(o.search, fallback.search),
-    toc: bool(o.toc, fallback.toc),
-    related: bool(o.related, fallback.related),
-    readingTime: bool(o.readingTime, fallback.readingTime),
-    progressBar: bool(o.progressBar, fallback.progressBar),
-    activityLog: bool(o.activityLog, fallback.activityLog),
-  }
-}
-
-function sanitizeMcp(input: unknown, fallback: McpSettings): McpSettings {
-  const o = (input ?? {}) as Partial<McpSettings>
-  return { enabled: bool(o.enabled, fallback.enabled) }
-}
-
-function sanitizeBackups(input: unknown, fallback: BackupSettings): BackupSettings {
-  const o = (input ?? {}) as Partial<BackupSettings>
-  return {
-    enabled: bool(o.enabled, fallback.enabled),
-    intervalDays: clampNumber(o.intervalDays, 1, 30, fallback.intervalDays),
-    keep: clampNumber(o.keep, 1, 30, fallback.keep),
-  }
-}
-
-// Owner CSS injected raw into <style>. Owner-only, so the only hazard is an
-// accidental `</style>` closing the tag early — strip it; pass the rest through.
-function sanitizeCss(value: unknown): string {
-  return typeof value === 'string' ? value.replace(/<\/style/gi, '') : ''
-}
-
-// Accept only a valid http(s) URL with no trailing slash; '' otherwise.
-function sanitizeUrl(value: unknown): string {
-  if (typeof value !== 'string' || !value.trim()) return ''
-  try {
-    const u = new URL(value.trim())
-    if (u.protocol !== 'http:' && u.protocol !== 'https:') return ''
-    return u.origin
-  } catch {
-    return ''
-  }
-}
 
 export const DEFAULT_SEO: SeoSettings = {
   autoSchema: true,
@@ -156,92 +40,6 @@ export const DEFAULT_FEATURES: FeatureSettings = {
   readingTime: true,
   progressBar: true,
   activityLog: true,
-}
-
-// Clamp a float into [min,max], keeping up to 2 decimals; fall back when invalid.
-function clampFloat(value: unknown, min: number, max: number, fallback: number): number {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
-  return Math.min(max, Math.max(min, Math.round(value * 100) / 100))
-}
-
-// One role's style, clamped. size rem [0.5,6]; line [0.8,3]; spacing em [-0.2,0.5].
-function sanitizeStyle(input: unknown, fallback: TypeStyle): TypeStyle {
-  const o = (input ?? {}) as Partial<TypeStyle>
-  return {
-    size: clampFloat(o.size, 0.5, 6, fallback.size),
-    line: clampFloat(o.line, 0.8, 3, fallback.line),
-    spacing: clampFloat(o.spacing, -0.2, 0.5, fallback.spacing),
-  }
-}
-
-// Back-compat: the first typography shape was flat ({ base, h1..h5, lineHeight,
-// letterSpacing }); lift those into the role map so an early save survives.
-function migrateTypography(o: Record<string, unknown>, base: TypographySettings): TypographySettings {
-  if (o.roles || typeof o.base !== 'number') return base
-  const num = (v: unknown, f: number) => (typeof v === 'number' && Number.isFinite(v) ? v : f)
-  const line = num(o.lineHeight, base.roles.body.line)
-  const sp = num(o.letterSpacing, base.roles.body.spacing)
-  const r = base.roles
-  return {
-    roles: {
-      ...r,
-      body: { size: num(o.base, r.body.size), line, spacing: sp },
-      h1: { ...r.h1, size: num(o.h1, r.h1.size) },
-      h2: { ...r.h2, size: num(o.h2, r.h2.size) },
-      h3: { ...r.h3, size: num(o.h3, r.h3.size) },
-      h4: { ...r.h4, size: num(o.h4, r.h4.size) },
-      h5: { ...r.h5, size: num(o.h5, r.h5.size) },
-    },
-    smoothing: bool(o.smoothing, base.smoothing),
-  }
-}
-
-function sanitizeTypography(input: unknown, fallback: TypographySettings): TypographySettings {
-  const o = (input ?? {}) as Record<string, unknown>
-  const base = migrateTypography(o, fallback)
-  const inRoles = (o.roles ?? {}) as Record<string, unknown>
-  const roles = {} as TypographySettings['roles']
-  for (const role of TYPE_ROLES) roles[role] = sanitizeStyle(inRoles[role], base.roles[role])
-  return { roles, smoothing: bool(o.smoothing, base.smoothing) }
-}
-
-// Family name -> safe CSS identifier (never trust raw into <style>): allow
-// letters/digits/space/hyphen, collapse the rest.
-function sanitizeFamily(value: unknown): string {
-  return typeof value === 'string' ? value.replace(/[^A-Za-z0-9 _-]/g, '').trim().slice(0, 64) : ''
-}
-
-// One uploaded weight: a known weight + a non-empty url. Maps the legacy single
-// `url` (no weight) to the 400 slot.
-function sanitizeFaces(input: unknown, legacyUrl: unknown): FontFace[] {
-  const raw = Array.isArray(input)
-    ? input
-    : typeof legacyUrl === 'string' && legacyUrl.trim()
-      ? [{ weight: 400, url: legacyUrl }]
-      : []
-  const byWeight = new Map<number, string>()
-  for (const f of raw) {
-    const o = (f ?? {}) as Partial<FontFace>
-    const w = typeof o.weight === 'number' ? o.weight : NaN
-    if (FONT_WEIGHTS.includes(w as (typeof FONT_WEIGHTS)[number]) && typeof o.url === 'string' && o.url.trim()) {
-      byWeight.set(w, o.url.trim())
-    }
-  }
-  return FONT_WEIGHTS.filter((w) => byWeight.has(w)).map((w) => ({ weight: w, url: byWeight.get(w)! }))
-}
-
-function sanitizeFont(input: unknown, fallback: FontSettings): FontSettings {
-  const o = (input ?? {}) as Record<string, unknown>
-  const family = o.family !== undefined ? sanitizeFamily(o.family) : fallback.family
-  const faces = sanitizeFaces(o.faces, o.url)
-  // Need a family AND at least one face; otherwise "no custom font".
-  return family && faces.length ? { family, faces } : DEFAULT_FONT
-}
-
-// font URL -> @font-face `format(...)` hint, by extension. Unknown -> omit it.
-function fontFormat(url: string): string {
-  const ext = url.split(/[?#]/)[0].split('.').pop()?.toLowerCase()
-  return ext === 'woff2' ? 'woff2' : ext === 'woff' ? 'woff' : ext === 'ttf' ? 'truetype' : ext === 'otf' ? 'opentype' : ''
 }
 
 // Per-role type CSS vars on :root (+ optional font-smoothing). Injected after
@@ -309,12 +107,6 @@ export function resolveSiteUrl(s: SiteSettings): string {
 // PWA / home-screen icon: app icon → favicon → bundled `/app-icon.png`.
 export function resolveAppIcon(s: SiteSettings): string {
   return s.appIconUrl || s.faviconUrl || '/app-icon.png'
-}
-
-// Clamp a possibly-invalid number into a range, falling back to a default.
-function clampNumber(value: unknown, min: number, max: number, fallback: number): number {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
-  return Math.min(max, Math.max(min, Math.round(value)))
 }
 
 // Settings merged over defaults; defaults on any error. `React.cache` dedupes per

--- a/src/lib/slugs.test.ts
+++ b/src/lib/slugs.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the data layer: ensureSlugFree queries posts + pages directly via db().
+// Each call chains .from(table).select('slug').eq('slug', slug).maybeSingle().
+const hits: { posts: { slug: string } | null; pages: { slug: string } | null } = {
+  posts: null,
+  pages: null,
+}
+
+vi.mock('@/lib/db', () => ({
+  DB_TAG: 'db',
+  db: () => ({
+    from: (table: 'posts' | 'pages') => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () => Promise.resolve({ data: hits[table] }),
+        }),
+      }),
+    }),
+  }),
+}))
+
+import { ensureSlugFree, SlugConflictError } from '@/lib/slugs'
+
+beforeEach(() => {
+  hits.posts = null
+  hits.pages = null
+})
+
+describe('ensureSlugFree (posts + pages share one /{slug} namespace)', () => {
+  it('throws SlugConflictError when a post already owns the slug', async () => {
+    hits.posts = { slug: 'hello' }
+    await expect(ensureSlugFree('hello', 'post')).rejects.toBeInstanceOf(SlugConflictError)
+  })
+
+  it('throws when a PAGE owns the slug a new post wants (cross-table)', async () => {
+    hits.pages = { slug: 'about' }
+    await expect(ensureSlugFree('about', 'post')).rejects.toBeInstanceOf(SlugConflictError)
+  })
+
+  it('resolves when the slug is free in both tables', async () => {
+    await expect(ensureSlugFree('brand-new', 'post')).resolves.toBeUndefined()
+  })
+
+  it('lets an item re-save its own slug (self-match by kind + slug)', async () => {
+    hits.posts = { slug: 'hello' }
+    await expect(ensureSlugFree('hello', 'post', 'hello')).resolves.toBeUndefined()
+  })
+
+  it('a page keeping its own slug still conflicts with a post of the same slug', async () => {
+    hits.posts = { slug: 'shared' } // a post owns it
+    hits.pages = { slug: 'shared' } // this very page owns it too
+    // Editing the page (self = page/shared) must still fail on the POST collision.
+    await expect(ensureSlugFree('shared', 'page', 'shared')).rejects.toBeInstanceOf(
+      SlugConflictError,
+    )
+  })
+})

--- a/src/lib/soft-delete.test.ts
+++ b/src/lib/soft-delete.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Invariant 6: every LIVE read filters `.is('deleted_at', null)`. A read path that
+// forgets it leaks trashed content to the public — silently (no build/test error).
+//
+// The mock db() builder ACTUALLY applies the .eq/.is filters the code chains, over
+// a seeded dataset of [one live row, one trashed row]. So if a read path drops its
+// `.is('deleted_at', null)`, the trashed row stops being filtered and these tests
+// fail — that is the leak guard. (textSearch/select/order/limit are accepted no-ops.)
+type Row = Record<string, unknown>
+const state = vi.hoisted(() => ({ posts: [] as Record<string, unknown>[] }))
+
+vi.mock('@/lib/db', () => {
+  type Resolve = (v: { data: Row[]; error: null }) => unknown
+  type Query = {
+    select: () => Query
+    order: () => Query
+    limit: () => Query
+    textSearch: () => Query
+    eq: (col: string, val: unknown) => Query
+    is: (col: string, val: unknown) => Query
+    maybeSingle: () => Promise<{ data: Row | null; error: null }>
+    then: (resolve: Resolve) => unknown
+  }
+  const makeBuilder = (rows: Row[]): Query => {
+    const filters: ((r: Row) => boolean)[] = []
+    const result = () => rows.filter((r) => filters.every((f) => f(r)))
+    const q: Query = {
+      select: () => q,
+      order: () => q,
+      limit: () => q,
+      textSearch: () => q,
+      eq: (col, val) => { filters.push((r) => r[col] === val); return q },
+      is: (col, val) => { filters.push((r) => (val === null ? r[col] == null : r[col] === val)); return q },
+      maybeSingle: () => Promise.resolve({ data: result()[0] ?? null, error: null }),
+      then: (resolve) => resolve({ data: result(), error: null }),
+    }
+    return q
+  }
+  return { DB_TAG: 'db', db: () => ({ from: () => makeBuilder(state.posts) }) }
+})
+
+import { getIndex, getPublicPosts, searchPosts, getPost } from '@/lib/posts'
+
+const LIVE: Row = {
+  slug: 'live-post', title: 'Live', date: '2020-01-01', status: 'published',
+  categories: [], tags: [], featured_image: null, excerpt: null,
+  reading_minutes: 1, content: 'body', deleted_at: null,
+}
+const TRASHED: Row = { ...LIVE, slug: 'trashed-post', title: 'Trashed', deleted_at: '2026-01-01T00:00:00Z' }
+
+beforeEach(() => {
+  state.posts = [LIVE, TRASHED]
+})
+
+describe('soft delete: trashed posts never leak to a live read', () => {
+  it('the listing (getIndex) excludes a trashed post', async () => {
+    const list = await getIndex()
+    expect(list.map((p) => p.slug)).toEqual(['live-post'])
+  })
+
+  it('the public listing (getPublicPosts) excludes a trashed post', async () => {
+    const list = await getPublicPosts()
+    expect(list.map((p) => p.slug)).toEqual(['live-post'])
+  })
+
+  it('search (searchPosts) excludes a trashed post', async () => {
+    const hits = await searchPosts('anything')
+    expect(hits.map((p) => p.slug)).toEqual(['live-post'])
+  })
+
+  it('the single read (getPost) returns null for a trashed slug', async () => {
+    expect(await getPost('trashed-post')).toBeNull()
+  })
+
+  it('the single read (getPost) still returns a live post', async () => {
+    const post = await getPost('live-post')
+    expect(post?.slug).toBe('live-post')
+  })
+})

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import {
+  slugify,
+  deriveExcerpt,
+  clampExcerpt,
+  readingMinutes,
+  isPublicallyVisible,
+  extractImageUrls,
+} from '@/lib/utils'
+
+describe('slugify', () => {
+  it('strips Vietnamese diacritics and maps đ -> d', () => {
+    expect(slugify('Suy nghĩ về Đời')).toBe('suy-nghi-ve-doi')
+  })
+
+  it('collapses spaces/symbols and trims leading/trailing hyphens', () => {
+    expect(slugify('  Hello, World!  ')).toBe('hello-world')
+  })
+})
+
+describe('readingMinutes', () => {
+  it('is at least 1 minute for short content', () => {
+    expect(readingMinutes('a few words here')).toBe(1)
+  })
+
+  it('approximates ~200 words per minute', () => {
+    const words = Array(400).fill('word').join(' ')
+    expect(readingMinutes(words)).toBe(2)
+  })
+})
+
+describe('deriveExcerpt', () => {
+  it('returns the whole text when under the word limit', () => {
+    expect(deriveExcerpt('short body text', 50)).toBe('short body text')
+  })
+
+  it('cuts at maxWords and appends an ellipsis', () => {
+    const body = Array(60).fill('w').join(' ')
+    const out = deriveExcerpt(body, 50)
+    expect(out.endsWith('...')).toBe(true)
+    expect(out.split(' ')).toHaveLength(50) // 50 words; "..." sticks to the last one
+  })
+
+  it('strips markdown image/link syntax from the excerpt', () => {
+    expect(deriveExcerpt('![alt](media/x.jpg) real [text](/l) here')).toBe('real text here')
+  })
+})
+
+describe('clampExcerpt', () => {
+  it('cuts on a word boundary with an ellipsis past the char limit', () => {
+    const out = clampExcerpt('one two three four five', 11)
+    expect(out).toBe('one two...')
+  })
+})
+
+describe('isPublicallyVisible', () => {
+  it('is false for a draft regardless of date', () => {
+    expect(isPublicallyVisible('draft', '2000-01-01')).toBe(false)
+  })
+
+  it('is false for a published post dated in the future', () => {
+    const future = new Date(Date.now() + 86_400_000).toISOString()
+    expect(isPublicallyVisible('published', future)).toBe(false)
+  })
+
+  it('is true for a published post dated in the past', () => {
+    expect(isPublicallyVisible('published', '2000-01-01')).toBe(true)
+  })
+})
+
+describe('extractImageUrls', () => {
+  it('collects de-duped image URLs in order', () => {
+    const content = '![a](https://h/x.jpg) <img src="https://h/y.png"> again https://h/x.jpg'
+    expect(extractImageUrls(content)).toEqual(['https://h/x.jpg', 'https://h/y.png'])
+  })
+})

--- a/src/lib/video.test.ts
+++ b/src/lib/video.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { videoEmbed, isVideoUrl } from '@/lib/video'
+
+describe('videoEmbed', () => {
+  it('maps a YouTube watch URL to a nocookie embed', () => {
+    expect(videoEmbed('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toEqual({
+      kind: 'youtube',
+      embed: 'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ',
+    })
+  })
+
+  it('maps a youtu.be short link too', () => {
+    expect(videoEmbed('https://youtu.be/dQw4w9WgXcQ')?.embed).toBe(
+      'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ',
+    )
+  })
+
+  it('maps a Vimeo URL to a player embed', () => {
+    expect(videoEmbed('https://vimeo.com/123456789')).toEqual({
+      kind: 'vimeo',
+      embed: 'https://player.vimeo.com/video/123456789',
+    })
+  })
+
+  it('maps a TikTok video URL to an embed', () => {
+    expect(videoEmbed('https://www.tiktok.com/@user/video/7234567890123456789')?.kind).toBe(
+      'tiktok',
+    )
+  })
+
+  it('returns null for a non-video URL', () => {
+    expect(videoEmbed('https://example.com/article')).toBeNull()
+    expect(isVideoUrl('https://example.com/article')).toBe(false)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+// Minimal vitest setup for the offline seam tests.
+// - `@` alias mirrors tsconfig paths (avoids a vite-tsconfig-paths dependency).
+// - A FAKE Blob token lets blob.ts derive a deterministic store host so the
+//   collapse/expand round-trip is checkable without real env / network.
+export default defineConfig({
+  resolve: {
+    alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) },
+  },
+  test: {
+    environment: 'node',
+    env: { BLOB_READ_WRITE_TOKEN: 'vercel_blob_rw_teststore_secretabc' },
+  },
+})


### PR DESCRIPTION
Make "verify" a single command and codify the load-bearing invariants so debugging proves instead of guesses. **No runtime behaviour change.**

## What
- **`npm run check:all`** = typecheck + lint + `check:routes` / `check:filesize` / `check:no-any` / `check:token-bust` + the vitest suite. Offline, no creds. Codifies the manual greps that lived in `CHECKLIST.md` / `audit/README.md`.
- **`check:consistency:live`** (separate, not in check:all) diffs `media`/`files` rows vs the real Blob store; skips cleanly without `.env.local`.
- **62-test vitest seam suite (<0.5s)** pinning the invariants: blob collapse/expand round-trip, shared slug namespace, revalidate SUPERSET, markdown raw-HTML escaping + ToC anchor sync, soft-delete (trashed content never leaks to a live read).
- **Refactor (behaviour-preserving):** split `lib/media.ts` → `lib/image.ts` and `lib/settings.ts` → `lib/settings-sanitize.ts` under the 400-line cap; one-way imports, all re-exports kept.
- **Docs:** CLAUDE.md 504 → 199 lines with a per-area DEBUG ROUTER + numbered Invariants (each citing its test/guard); topic detail moved to `docs/{conventions,features,seo-pwa,mcp,backups}.md`.

## Verify
`npm run check:all` → exit 0 (62 tests green). No `src/` behaviour changed; the 57 pre-existing-equivalent seam tests + 5 new soft-delete tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)