### PR TITLE
refactor: single-source soft-delete filter via liveOnly() (v1.1.0-beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 2026-06-23 (v1.1.0-beta — soft-delete filter is enforced in one place)
+- **refactor: `liveOnly()` (in `lib/db.ts`) is the single home of the soft-delete predicate.**
+  Every live read of a soft-deletable table (posts/pages/media/files) now wraps its query in
+  `liveOnly(...)` instead of hand-writing `.is('deleted_at', null)` at each of the 9 call sites —
+  so the column + null check are defined ONCE and can't drift. Trash views still read the complement
+  (`.not('deleted_at','is',null)`) directly. Behaviour-preserving; the `soft-delete.test.ts` suite
+  (listing/public/search/single) guards it. First tagged **beta** of the 1.1 line. `v1.1.0-beta`.
+
 ## 2026-06-23 (v1.0.18 — verification is one command now, not a reading session)
 - **build: `npm run check:all` is the Definition of Done** — typecheck + lint + four static
   invariant checks (`check:routes`, `check:filesize`, `check:no-any`, `check:token-bust`) + the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,8 +88,8 @@ Each is *Enforced at* code + pinned by a *Test* or static *Guard* — all run by
 5. **Raw HTML in markdown is escaped, never executed.** `html` renderer → `escapeHtml`; `safeHref` drops
    `javascript:`/`data:`/`vbscript:`. *Enforced at:* `PostContent.tsx`. *Test:* `post-content.test.ts`.
 6. **Every delete is a soft delete.** `deleteX()` sets `deleted_at`; EVERY live read filters
-   `.is('deleted_at', null)` (each read writes its own WHERE — no shared helper; guarantee by repetition).
-   *Enforced at:* data-layer files + `docs/features.md`. *Test:* `lib/soft-delete.test.ts` (4 read paths).
+   `.is('deleted_at', null)` via `liveOnly()` (`db.ts`) — predicate defined ONCE; Trash reads the
+   complement. *Enforced at:* data-layer files + `docs/features.md`. *Test:* `lib/soft-delete.test.ts`.
 7. **Cache-bust is asymmetric.** Out-of-band writes (`backup_state`) MUST `revalidateTag(DB_TAG)`; MCP
    token routes MUST NOT (`force-no-store`; busting `db` over-purges public). *Enforced at:*
    `lib/backup-state.ts` vs `api/mcp/tokens`. *Test:* `check:token-bust` (backup side = coarse tripwire).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# vibe**blog** &nbsp;`v1.0.18`
+# vibe**blog** &nbsp;`v1.1.0-beta`
 
 **An AI-operated personal blog platform.**
 Write and publish from a clean multilingual admin — or hand the keys to an AI agent and let it write, publish, and even deploy for you.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeblog",
-  "version": "1.0.18",
+  "version": "1.1.0-beta",
   "private": true,
   "license": "MIT",
   "browserslist": [

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -48,3 +48,12 @@ export function db(): SupabaseClient {
   })
   return _client
 }
+
+// Soft-delete predicate, defined ONCE (Invariant 6). EVERY live read of a
+// soft-deletable table (posts/pages/media/files) wraps its query in liveOnly, so
+// the column + null check live here and nowhere else — a read can't drift to a
+// different filter. Trash views read the complement directly
+// (`.not('deleted_at', 'is', null)`); those must NOT use this.
+export function liveOnly<Q extends { is(column: 'deleted_at', value: null): Q }>(query: Q): Q {
+  return query.is('deleted_at', null)
+}

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -9,7 +9,7 @@ import type { FileItem } from '@/types'
 import {
   uploadFile, expandBlob, collapseBlob, deleteByPathname, listBlobs,
 } from '@/lib/blob'
-import { db } from '@/lib/db'
+import { db, liveOnly } from '@/lib/db'
 import { slugify } from '@/lib/utils'
 
 // contentType -> extension. `.ico` arrives as x-icon / vnd.microsoft.icon.
@@ -143,10 +143,8 @@ function rowToItem(row: FileRow): FileItem {
 // Non-cached read, newest first (mutating helpers return authoritative state).
 async function listFiles(): Promise<FileItem[]> {
   try {
-    const { data, error } = await db()
-      .from('files')
-      .select('*')
-      .is('deleted_at', null) // live library only; trashed files live in the Trash view
+    // liveOnly = `.is('deleted_at', null)` — trashed files live in the Trash view.
+    const { data, error } = await liveOnly(db().from('files').select('*'))
       .order('uploaded_at', { ascending: false })
     if (error || !data) {
       if (error) console.error(`[ERROR] files.listFiles: ${error.message}`)

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -8,7 +8,7 @@ import type { MediaItem } from '@/types'
 import {
   uploadFile, blobUrl, deleteByPathname, collapseBlob, expandBlob, listBlobs,
 } from '@/lib/blob'
-import { db } from '@/lib/db'
+import { db, liveOnly } from '@/lib/db'
 import { slugify } from '@/lib/utils'
 import {
   imageSize, safeSize, makeThumb, makeDisplay, RASTER, PASSTHROUGH, SIZES,
@@ -46,10 +46,8 @@ function rowToItem(row: MediaRow): MediaItem {
 // return authoritative current state).
 async function listMedia(): Promise<MediaItem[]> {
   try {
-    const { data, error } = await db()
-      .from('media')
-      .select('*')
-      .is('deleted_at', null) // live library only; trashed images live in the Trash view
+    // liveOnly = `.is('deleted_at', null)` — trashed images live in the Trash view.
+    const { data, error } = await liveOnly(db().from('media').select('*'))
       .order('uploaded_at', { ascending: false })
     if (error || !data) {
       if (error) console.error(`[ERROR] media.listMedia: ${error.message}`)
@@ -353,7 +351,7 @@ export async function finalizeVariants(pathnames: string[]): Promise<void> {
 // Backfill thumbs for rows that have none (script/migration imports). Raster gets a
 // real `-thumb.webp`; everything else points `thumb` at the original. Cron-swept.
 export async function finalizePendingThumbs(): Promise<number> {
-  const { data } = await db().from('media').select('path').is('thumb', null).is('deleted_at', null)
+  const { data } = await liveOnly(db().from('media').select('path').is('thumb', null))
   const targets = ((data as { path: string }[] | null) ?? [])
   let done = 0
   for (const { path } of targets) {
@@ -384,7 +382,7 @@ export async function finalizeContentMedia(content: string, featuredImage?: stri
 // Cron backstop: sweep all raster originals still pending variants, in case a
 // background finalize never ran (e.g. the function froze after the save response).
 export async function finalizePendingVariants(): Promise<number> {
-  const { data } = await db().from('media').select('path').eq('variants', false).is('deleted_at', null)
+  const { data } = await liveOnly(db().from('media').select('path').eq('variants', false))
   const paths = ((data as { path: string }[] | null) ?? [])
     .map((r) => r.path)
     .filter((p) => /\.(jpe?g|png)$/i.test(p))

--- a/src/lib/pages.ts
+++ b/src/lib/pages.ts
@@ -4,7 +4,7 @@
 import { cache } from 'react'
 import type { Page, PageWithContent } from '@/types'
 import { collapseBlob, expandBlob } from '@/lib/blob'
-import { db } from '@/lib/db'
+import { db, liveOnly } from '@/lib/db'
 import { slugify } from '@/lib/utils'
 import { ensureSlugFree } from '@/lib/slugs'
 
@@ -31,7 +31,7 @@ function rowToMeta(row: PageRow): Page {
 // dedupes within one render; every request re-reads Postgres (always current).
 const readIndex = cache(async (): Promise<Page[]> => {
   try {
-    const { data, error } = await db().from('pages').select(META_COLS).is('deleted_at', null)
+    const { data, error } = await liveOnly(db().from('pages').select(META_COLS))
     if (error || !data) {
       if (error) console.error(`[ERROR] pages.readIndex: ${error.message}`)
       return []
@@ -57,7 +57,7 @@ export async function getPublicPages(): Promise<Page[]> {
 // Read one full page. `React.cache` dedupes within one request only.
 export const getPage = cache(async (slug: string): Promise<PageWithContent | null> => {
   try {
-    const { data, error } = await db().from('pages').select('*').eq('slug', slug).is('deleted_at', null).maybeSingle()
+    const { data, error } = await liveOnly(db().from('pages').select('*').eq('slug', slug)).maybeSingle()
     if (error || !data) return null
     const row = data as PageRow
     return { ...rowToMeta(row), content: expandBlob(row.content ?? '') }

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -5,7 +5,7 @@
 import { cache } from 'react'
 import type { Post, PostWithContent } from '@/types'
 import { collapseBlob, expandBlob } from '@/lib/blob'
-import { db } from '@/lib/db'
+import { db, liveOnly } from '@/lib/db'
 import { slugify, deriveExcerpt, clampExcerpt, isPublicallyVisible, readingMinutes } from '@/lib/utils'
 import { ensureSlugFree } from '@/lib/slugs'
 import { pushRevision, renameRevisions, deleteRevisions } from '@/lib/revisions'
@@ -79,10 +79,8 @@ function projection(p: PostWithContent): string {
 // request re-reads Postgres (always current, transactional).
 const readIndex = cache(async (): Promise<Post[]> => {
   try {
-    const { data, error } = await db()
-      .from('posts')
-      .select(META_COLS)
-      .is('deleted_at', null) // live posts only; trashed rows are excluded everywhere but the Trash view
+    // liveOnly = `.is('deleted_at', null)` — trashed rows excluded everywhere but the Trash view.
+    const { data, error } = await liveOnly(db().from('posts').select(META_COLS))
       .order('date', { ascending: false })
     if (error || !data) {
       if (error) console.error(`[ERROR] posts.readIndex: ${error.message}`)
@@ -113,12 +111,13 @@ export async function searchPosts(query: string): Promise<Post[]> {
   const q = query.trim()
   if (!q) return []
   try {
-    const { data, error } = await db()
-      .from('posts')
-      .select(META_COLS)
-      .textSearch('search', q, { type: 'websearch', config: 'simple' })
-      .eq('status', 'published')
-      .is('deleted_at', null) // never surface trashed posts in search
+    const { data, error } = await liveOnly(
+      db()
+        .from('posts')
+        .select(META_COLS)
+        .textSearch('search', q, { type: 'websearch', config: 'simple' })
+        .eq('status', 'published'), // never surface trashed posts in search
+    )
       .order('date', { ascending: false })
       .limit(50)
     if (error || !data) {
@@ -135,7 +134,7 @@ export async function searchPosts(query: string): Promise<Post[]> {
 // Read one full post. `React.cache` dedupes across generateMetadata + render in one request.
 export const getPost = cache(async (slug: string): Promise<PostWithContent | null> => {
   try {
-    const { data, error } = await db().from('posts').select('*').eq('slug', slug).is('deleted_at', null).maybeSingle()
+    const { data, error } = await liveOnly(db().from('posts').select('*').eq('slug', slug)).maybeSingle()
     if (error || !data) return null
     const row = data as PostRow
     return { ...rowToMeta(row), content: expandBlob(row.content ?? '') }

--- a/src/lib/soft-delete.test.ts
+++ b/src/lib/soft-delete.test.ts
@@ -37,7 +37,13 @@ vi.mock('@/lib/db', () => {
     }
     return q
   }
-  return { DB_TAG: 'db', db: () => ({ from: () => makeBuilder(state.posts) }) }
+  // liveOnly mirrors the real helper: apply the soft-delete filter to the query.
+  // If a read path drops liveOnly/`.is`, the trashed row stops being filtered.
+  return {
+    DB_TAG: 'db',
+    db: () => ({ from: () => makeBuilder(state.posts) }),
+    liveOnly: (q: Query) => q.is('deleted_at', null),
+  }
 })
 
 import { getIndex, getPublicPosts, searchPosts, getPost } from '@/lib/posts'


### PR DESCRIPTION
Enforce-by-construction for **Invariant 6 (soft delete)**. Behaviour-preserving.

## What
- New `liveOnly(query)` in `lib/db.ts` applies `.is('deleted_at', null)` — the soft-delete predicate now lives in ONE place.
- All 9 live-read call sites (posts ×3, pages ×2, media ×3, files ×1) wrap their query in `liveOnly(...)` instead of hand-writing the filter, so it can't drift.
- Trash views are unchanged — they read the complement (`.not('deleted_at','is',null)`) directly.
- CLAUDE.md invariant #6 updated; `soft-delete.test.ts` mock now exercises `liveOnly` (still guards listing/public/search/single).

## Verify
`npm run check:all` → exit 0 (62 tests green). No behaviour change.

Cuts **v1.1.0-beta** (first beta of the 1.1 line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)