### PR TITLE
feat(appearance): per-palette visibility; hide switcher when one is left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 2026-06-23 (v1.1.0-beta — per-palette visibility; switcher hides when one is left)
+- **feat(appearance): the owner can turn each color palette on/off for visitors.** New
+  `settings.enabledPalettes` (allow-list of preset ids). Admin → Appearance shows a "Shown to
+  visitors" checkbox per palette; the default palette is locked on so the set is never empty.
+  The public + admin palette switcher lists only enabled palettes (`enabledPaletteOptions`), and
+  **`PaletteToggle` renders nothing when ≤1 palette is enabled** — so a one-palette site has no
+  theme-switch icon at all. The no-FOUC script ignores a stored palette that is no longer enabled
+  (falls back to the default, no flash). Disabled palettes remain fully editable. Migration-safe:
+  legacy settings with no `enabledPalettes` read as "all on" (`sanitizeEnabledPalettes`, pinned by
+  `settings-sanitize.test.ts`). `v1.1.0-beta`.
+
 ## 2026-06-23 (v1.1.0-beta — soft-delete filter is enforced in one place)
 - **refactor: `liveOnly()` (in `lib/db.ts`) is the single home of the soft-delete predicate.**
   Every live read of a soft-deletable table (posts/pages/media/files) now wraps its query in

--- a/docs/features.md
+++ b/docs/features.md
@@ -86,6 +86,14 @@
   `AdvancedFields` (font smoothing = "Text rendering"); Advanced `McpFields` + custom-CSS.
   `McpFields` is the EXCEPTION to "no own state/save": the MCP enable toggle flows through the
   settings form, but its token manager has its own `/api/mcp/tokens` API (plaintext shown once).
+- **Palette visibility (`ThemeFields` "Shown to visitors").** `settings.enabledPalettes` is the
+  allow-list a visitor may switch between; each preset card has a checkbox. The DEFAULT palette
+  (`themePreset`) is always shown (its checkbox is locked) so the set is never empty. `enabledPaletteOptions()`
+  filters the public + admin `PaletteToggle`; `PaletteToggle` renders `null` when ≤1 option (the
+  icon disappears). The no-FOUC script ignores a stored palette that is no longer enabled (falls
+  back to the default). Disabled palettes stay fully editable — visibility ≠ customization.
+  Sanitizer (`sanitizeEnabledPalettes`): known ids only, preset order, default forced in; a missing
+  field (legacy settings) = all on. Pinned by `settings-sanitize.test.ts`.
 - Each tab: `grid lg:grid-cols-2 items-start` (explicit columns, NOT CSS `columns`).
 - **Save calls `router.refresh()`** so the admin shell + public header reflect the change
   immediately.

--- a/src/app/(blog)/layout.tsx
+++ b/src/app/(blog)/layout.tsx
@@ -1,7 +1,7 @@
 // Public blog shell: header (from site settings) + content column + footer.
 import Link from 'next/link'
 import { getSettings } from '@/lib/settings'
-import { paletteOptions } from '@/lib/themes'
+import { enabledPaletteOptions } from '@/lib/themes'
 import { ThemeToggle } from '@/components/theme/ThemeToggle'
 import { PaletteToggle } from '@/components/theme/PaletteToggle'
 import { HeaderMenu } from '@/components/blog/HeaderMenu'
@@ -51,7 +51,7 @@ export default async function BlogLayout({ children }: { children: React.ReactNo
           </Link>
           <div className="flex shrink-0 items-center gap-0.5">
             {settings.features.search && <SearchTrigger lang={settings.language} />}
-            <PaletteToggle lang={settings.language} palettes={paletteOptions(settings.themes)} defaultId={settings.themePreset} />
+            <PaletteToggle lang={settings.language} palettes={enabledPaletteOptions(settings.themes, settings.enabledPalettes)} defaultId={settings.themePreset} />
             <ThemeToggle lang={settings.language} />
             <HeaderMenu items={settings.menu} lang={settings.language} />
           </div>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -4,7 +4,7 @@
 import { redirect } from 'next/navigation'
 import { getAuthState, signOut } from '@/lib/auth'
 import { getSettings } from '@/lib/settings'
-import { paletteOptions } from '@/lib/themes'
+import { enabledPaletteOptions } from '@/lib/themes'
 import { AdminI18nProvider } from '@/components/admin/I18nProvider'
 import { AdminSidebar } from '@/components/admin/AdminSidebar'
 
@@ -43,7 +43,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
         <AdminSidebar
           lang={language}
           signOut={signOutAction}
-          palettes={paletteOptions(settings.themes)}
+          palettes={enabledPaletteOptions(settings.themes, settings.enabledPalettes)}
           defaultPalette={settings.themePreset}
         />
         {/* Main column right of the sidebar. Full browser width (admin is column-based

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,8 +6,11 @@ import { getSettings, themesToCss, typographyToCss, fontToCss, getDefaultTheme, 
 import { blobOrigin } from '@/lib/blob'
 
 // Before paint: apply saved mode + palette to avoid a wrong-color flash. Default
-// palette is baked into :root, so only set data-palette when one is stored.
-const NO_FOUC = `(function(){try{var d=document.documentElement;var m=localStorage.getItem('theme')||'system';var dk=m==='dark'||(m==='system'&&matchMedia('(prefers-color-scheme: dark)').matches)||(m==='time'&&(function(){var h=new Date().getHours();return h>=18||h<6})());if(dk)d.classList.add('dark');var p=localStorage.getItem('palette');if(p)d.setAttribute('data-palette',p)}catch(e){}})();`
+// palette is baked into :root, so only set data-palette when a stored palette is
+// still ENABLED — a palette the owner has since hidden falls back to the default.
+function noFouc(enabled: string[]): string {
+  return `(function(){try{var d=document.documentElement;var m=localStorage.getItem('theme')||'system';var dk=m==='dark'||(m==='system'&&matchMedia('(prefers-color-scheme: dark)').matches)||(m==='time'&&(function(){var h=new Date().getHours();return h>=18||h<6})());if(dk)d.classList.add('dark');var p=localStorage.getItem('palette');if(p&&${JSON.stringify(enabled)}.indexOf(p)>-1)d.setAttribute('data-palette',p)}catch(e){}})();`
+}
 
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -46,7 +49,7 @@ export async function generateViewport(): Promise<Viewport> {
 }
 
 export default async function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
-  const { language, themes, themePreset, typography, customFont } = await getSettings()
+  const { language, themes, themePreset, enabledPalettes, typography, customFont } = await getSettings()
   const blob = blobOrigin()
   // No `antialiased` on <html>: it forces grayscale smoothing on Mac, thinning body text.
   return (
@@ -64,7 +67,7 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
         <style dangerouslySetInnerHTML={{ __html: themesToCss(themes, themePreset) }} />
         {/* Owner type scale → fs/lh/ls vars (overrides globals.css) + custom @font-face. */}
         <style dangerouslySetInnerHTML={{ __html: typographyToCss(typography) + fontToCss(customFont) }} />
-        <script dangerouslySetInnerHTML={{ __html: NO_FOUC }} />
+        <script dangerouslySetInnerHTML={{ __html: noFouc(enabledPalettes) }} />
         <ThemeProvider>
           <ToastProvider>{children}</ToastProvider>
         </ThemeProvider>

--- a/src/components/admin/SettingsView.tsx
+++ b/src/components/admin/SettingsView.tsx
@@ -133,8 +133,10 @@ export function SettingsView({ settings, presets }: { settings: SiteSettings; pr
                 presets={presets}
                 themes={s.themes}
                 defaultId={s.themePreset}
+                enabled={s.enabledPalettes}
                 onChangeThemes={(themes) => update({ themes })}
                 onSetDefault={(themePreset) => update({ themePreset })}
+                onChangeEnabled={(enabledPalettes) => update({ enabledPalettes })}
               />
             </Card>
           </div>

--- a/src/components/admin/ThemeFields.tsx
+++ b/src/components/admin/ThemeFields.tsx
@@ -41,39 +41,56 @@ function PresetCard({
   editing,
   isDefault,
   defaultLabel,
+  shown,
+  shownLabel,
   onPick,
+  onToggleShown,
 }: {
   name: string
   theme: ThemeSettings
   editing: boolean
   isDefault: boolean
   defaultLabel: string
+  shown: boolean // listed in the visitor's palette switcher
+  shownLabel: string
   onPick: () => void
+  onToggleShown: () => void
 }) {
   // No borders: the selected palette reads via full opacity + a bold name; the
-  // rest sit dimmed until hovered.
+  // rest sit dimmed until hovered. A hidden (not-shown) palette dims further so
+  // it reads as "off" at a glance — but stays fully editable.
+  const dim = editing ? '' : shown ? 'opacity-40 hover:opacity-100' : 'opacity-25 hover:opacity-100'
   return (
-    <button
-      type="button"
-      onClick={onPick}
-      aria-pressed={editing}
-      className={`group block w-full text-left transition ${editing ? '' : 'opacity-40 hover:opacity-100'}`}
-    >
-      <div className="flex h-11 overflow-hidden rounded-lg">
-        <MiniMode c={theme.light} />
-        <MiniMode c={theme.dark} />
-      </div>
-      <div className="mt-1.5 flex items-center justify-between gap-1 px-0.5">
-        <span className={`text-xs ${editing ? 'font-semibold text-neutral-900 dark:text-white' : 'font-medium text-neutral-500 dark:text-neutral-400'}`}>
-          {name}
-        </span>
-        {isDefault && (
-          <span className="rounded bg-neutral-900 px-1.5 py-0.5 text-xs font-medium text-white dark:bg-white dark:text-neutral-900">
-            {defaultLabel}
+    <div className={`group transition ${dim}`}>
+      <button type="button" onClick={onPick} aria-pressed={editing} className="block w-full text-left">
+        <div className="flex h-11 overflow-hidden rounded-lg">
+          <MiniMode c={theme.light} />
+          <MiniMode c={theme.dark} />
+        </div>
+        <div className="mt-1.5 flex items-center justify-between gap-1 px-0.5">
+          <span className={`text-xs ${editing ? 'font-semibold text-neutral-900 dark:text-white' : 'font-medium text-neutral-500 dark:text-neutral-400'}`}>
+            {name}
           </span>
-        )}
-      </div>
-    </button>
+          {isDefault && (
+            <span className="rounded bg-neutral-900 px-1.5 py-0.5 text-xs font-medium text-white dark:bg-white dark:text-neutral-900">
+              {defaultLabel}
+            </span>
+          )}
+        </div>
+      </button>
+      {/* Visibility toggle. The default palette is always shown (locked), so the
+          visitor never ends up with zero palettes. */}
+      <label className={`mt-1 flex items-center gap-1.5 px-0.5 text-xs ${isDefault ? 'cursor-not-allowed text-neutral-400 dark:text-neutral-600' : 'cursor-pointer text-neutral-500 dark:text-neutral-400'}`}>
+        <input
+          type="checkbox"
+          checked={shown}
+          disabled={isDefault}
+          onChange={onToggleShown}
+          className="h-3.5 w-3.5 rounded border-neutral-300 dark:border-neutral-600"
+        />
+        {shownLabel}
+      </label>
+    </div>
   )
 }
 
@@ -132,21 +149,31 @@ type Props = {
   presets: ThemePreset[]
   themes: Record<string, ThemeSettings>
   defaultId: string
+  enabled: string[]
   onChangeThemes: (themes: Record<string, ThemeSettings>) => void
   onSetDefault: (id: string) => void
+  onChangeEnabled: (ids: string[]) => void
 }
 
-export function ThemeFields({ presets, themes, defaultId, onChangeThemes, onSetDefault }: Props) {
+export function ThemeFields({ presets, themes, defaultId, enabled, onChangeThemes, onSetDefault, onChangeEnabled }: Props) {
   const t = useAdminT()
   // Which palette is being edited (local UI state — start at the visitor default).
   const [editingId, setEditingId] = useState(defaultId)
   const theme = themes[editingId] ?? getPreset(editingId).theme
   const builtin = getPreset(editingId).theme
+  const enabledSet = new Set(enabled)
 
   const setColor = (mode: keyof ThemeSettings, key: ColorKey, value: string) =>
     onChangeThemes({ ...themes, [editingId]: { ...theme, [mode]: { ...theme[mode], [key]: value } } })
   const resetMode = (mode: keyof ThemeSettings) =>
     onChangeThemes({ ...themes, [editingId]: { ...theme, [mode]: { ...builtin[mode] } } })
+  // Flip one palette's visibility; the default is always kept on (preset order).
+  const toggleShown = (id: string) => {
+    const on = new Set(enabledSet)
+    on.has(id) ? on.delete(id) : on.add(id)
+    on.add(defaultId)
+    onChangeEnabled(presets.filter((p) => on.has(p.id)).map((p) => p.id))
+  }
 
   return (
     <div className="space-y-4">
@@ -163,7 +190,10 @@ export function ThemeFields({ presets, themes, defaultId, onChangeThemes, onSetD
               editing={p.id === editingId}
               isDefault={p.id === defaultId}
               defaultLabel={t.themeDefault}
+              shown={enabledSet.has(p.id)}
+              shownLabel={t.paletteShown}
               onPick={() => setEditingId(p.id)}
+              onToggleShown={() => toggleShown(p.id)}
             />
           ))}
         </div>
@@ -179,6 +209,7 @@ export function ThemeFields({ presets, themes, defaultId, onChangeThemes, onSetD
             </button>
           )}
         </div>
+        <p className="text-xs text-neutral-400 dark:text-neutral-500">{t.paletteVisibilityHint}</p>
       </div>
 
       <ModeBox

--- a/src/components/theme/PaletteToggle.tsx
+++ b/src/components/theme/PaletteToggle.tsx
@@ -87,6 +87,9 @@ export function PaletteToggle({
   const currentName = palettes.find((p) => p.id === current)
   const triggerText = label ?? (currentName ? nameOf(currentName) : s.palette)
 
+  // Nothing to switch between: hide the control entirely (owner enabled ≤1 palette).
+  if (palettes.length <= 1) return null
+
   return (
     <div className="relative">
       <button

--- a/src/lib/settings-sanitize.test.ts
+++ b/src/lib/settings-sanitize.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeEnabledPalettes } from '@/lib/settings-sanitize'
+import { ALL_PALETTE_IDS } from '@/lib/themes'
+
+// `enabledPalettes` is the visitor-switcher allow-list. Invariants pinned here:
+// the default is ALWAYS included (so the switcher never goes empty), only known
+// preset ids survive, preset order is preserved, and a missing field (legacy
+// settings) means "all on".
+describe('sanitizeEnabledPalettes', () => {
+  it('defaults to ALL palettes when the field is missing / not an array', () => {
+    expect(sanitizeEnabledPalettes(undefined, 'mono')).toEqual(ALL_PALETTE_IDS)
+    expect(sanitizeEnabledPalettes(null, 'mono')).toEqual(ALL_PALETTE_IDS)
+    expect(sanitizeEnabledPalettes('mono', 'mono')).toEqual(ALL_PALETTE_IDS)
+  })
+
+  it('always includes the default, even if absent from the input', () => {
+    expect(sanitizeEnabledPalettes(['ocean'], 'mono')).toContain('mono')
+    // empty array collapses to just the default -> switcher hides (one option)
+    expect(sanitizeEnabledPalettes([], 'sepia')).toEqual(['sepia'])
+  })
+
+  it('keeps only known preset ids, in preset order', () => {
+    const out = sanitizeEnabledPalettes(['amber', 'bogus', 'ocean', 42, 'mono'], 'mono')
+    expect(out).not.toContain('bogus')
+    expect(out).toEqual(ALL_PALETTE_IDS.filter((id) => ['amber', 'ocean', 'mono'].includes(id)))
+  })
+
+  it('falls back to the built-in default when the given default is invalid', () => {
+    expect(sanitizeEnabledPalettes(['ocean'], 'not-a-preset')).toContain('mono')
+  })
+})

--- a/src/lib/settings-sanitize.ts
+++ b/src/lib/settings-sanitize.ts
@@ -65,6 +65,18 @@ export function sanitizeThemes(input: unknown, base: Record<string, ThemeSetting
   return out
 }
 
+// Palettes offered to visitors: keep only known preset ids, in preset order, and
+// ALWAYS include the default (it must stay selectable). A non-array (missing field,
+// e.g. legacy settings) means "all on"; an empty/garbage array collapses to just
+// the default — which hides the switcher (one option). Invariant for `enabledPalettes`.
+export function sanitizeEnabledPalettes(input: unknown, defaultId: string): string[] {
+  const def = isPresetId(defaultId) ? defaultId : DEFAULT_PRESET_ID
+  if (!Array.isArray(input)) return THEME_PRESETS.map((p) => p.id)
+  const want = new Set(input.filter((x): x is string => typeof x === 'string'))
+  want.add(def)
+  return THEME_PRESETS.map((p) => p.id).filter((id) => want.has(id))
+}
+
 const bool = (v: unknown, fallback: boolean): boolean => (typeof v === 'boolean' ? v : fallback)
 
 export function sanitizeSeo(input: unknown, fallback: SeoSettings): SeoSettings {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -8,9 +8,9 @@ import { collapseBlob, expandBlob, deleteByPathname } from '@/lib/blob'
 import { renderLogo } from '@/lib/files'
 import { db } from '@/lib/db'
 import { isSiteLang } from '@/locales/langs'
-import { DEFAULT_PRESET_ID, isPresetId, defaultThemes, DEFAULT_TYPOGRAPHY, DEFAULT_FONT, TYPE_ROLES } from '@/lib/themes'
+import { DEFAULT_PRESET_ID, isPresetId, defaultThemes, ALL_PALETTE_IDS, DEFAULT_TYPOGRAPHY, DEFAULT_FONT, TYPE_ROLES } from '@/lib/themes'
 import {
-  sanitizeMenu, migrateThemes, sanitizeThemes, sanitizeSeo, sanitizeFeatures, sanitizeMcp,
+  sanitizeMenu, migrateThemes, sanitizeThemes, sanitizeEnabledPalettes, sanitizeSeo, sanitizeFeatures, sanitizeMcp,
   sanitizeBackups, sanitizeCss, sanitizeUrl, sanitizeTypography, sanitizeFont, fontFormat, clampNumber,
 } from '@/lib/settings-sanitize'
 
@@ -87,6 +87,7 @@ export const DEFAULT_SETTINGS: SiteSettings = {
   customCss: '',
   menu: [],
   themePreset: DEFAULT_PRESET_ID,
+  enabledPalettes: ALL_PALETTE_IDS,
   themes: defaultThemes(),
   typography: DEFAULT_TYPOGRAPHY,
   customFont: DEFAULT_FONT,
@@ -129,6 +130,7 @@ export const getSettings = cache(async (): Promise<SiteSettings> => {
       excerptLength: clampNumber(stored.excerptLength, 10, 100, DEFAULT_SETTINGS.excerptLength),
       customCss: sanitizeCss(stored.customCss),
       themePreset: isPresetId(stored.themePreset) ? stored.themePreset : DEFAULT_PRESET_ID,
+      enabledPalettes: sanitizeEnabledPalettes(stored.enabledPalettes, isPresetId(stored.themePreset) ? stored.themePreset : DEFAULT_PRESET_ID),
       themes: sanitizeThemes(stored.themes, migrateThemes(stored as Record<string, unknown>)),
       typography: sanitizeTypography(stored.typography, DEFAULT_TYPOGRAPHY),
       customFont: (() => {
@@ -169,6 +171,10 @@ export async function saveSettings(input: Partial<SiteSettings>): Promise<SiteSe
     logoRenderHeight = rendered?.height ?? 0
   }
 
+  // The (possibly new) default palette — used both as `themePreset` and as the
+  // always-included member of `enabledPalettes`.
+  const themePreset = isPresetId(input.themePreset) ? input.themePreset : current.themePreset
+
   const next: SiteSettings = {
     language: isSiteLang(input.language) ? input.language : current.language,
     title: (input.title ?? current.title).trim() || DEFAULT_SETTINGS.title,
@@ -188,7 +194,8 @@ export async function saveSettings(input: Partial<SiteSettings>): Promise<SiteSe
     excerptLength: clampNumber(input.excerptLength, 10, 100, current.excerptLength),
     customCss: input.customCss !== undefined ? sanitizeCss(input.customCss) : current.customCss,
     menu: sanitizeMenu(input.menu, current.menu),
-    themePreset: isPresetId(input.themePreset) ? input.themePreset : current.themePreset,
+    themePreset,
+    enabledPalettes: sanitizeEnabledPalettes(input.enabledPalettes ?? current.enabledPalettes, themePreset),
     themes: sanitizeThemes(input.themes, current.themes),
     typography: sanitizeTypography(input.typography, current.typography),
     customFont: sanitizeFont(input.customFont, current.customFont),

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -119,10 +119,22 @@ export function getDefaultTheme(themes: Record<string, ThemeSettings>, defaultId
   return themes[defaultId] ?? themes[DEFAULT_PRESET_ID] ?? THEME_PRESETS[0].theme
 }
 
+// Every built-in palette id, in display order. The default "everything on" set.
+export const ALL_PALETTE_IDS: string[] = THEME_PRESETS.map((p) => p.id)
+
 // Compact palette list for the client switcher: preset order, display name, and
 // the (customized) light colors used to render the preview swatch.
 export function paletteOptions(themes: Record<string, ThemeSettings>): { id: string; name: string; light: ThemeColors }[] {
   return THEME_PRESETS.map((p) => ({ id: p.id, name: p.name, light: (themes[p.id] ?? p.theme).light }))
+}
+
+// Switcher options limited to the visitor-enabled palettes (preset order kept).
+export function enabledPaletteOptions(
+  themes: Record<string, ThemeSettings>,
+  enabled: string[],
+): { id: string; name: string; light: ThemeColors }[] {
+  const on = new Set(enabled)
+  return paletteOptions(themes).filter((p) => on.has(p.id))
 }
 
 function vars(c: ThemeColors): string {

--- a/src/locales/admin/de.ts
+++ b/src/locales/admin/de.ts
@@ -142,6 +142,8 @@ const de = {
   themePresetHint: 'Jede Palette hat eigene Farben. Wähle eine zum Bearbeiten; Besucher können die Palette auf der Seite wechseln und sehen deine Änderungen. Zurücksetzen stellt die Standardfarben dieser Palette wieder her.',
   themeDefault: 'Standard',
   themeSetDefault: 'Als Standard',
+  paletteShown: 'Für Besucher sichtbar',
+  paletteVisibilityHint: 'Deaktiviere eine Palette, um sie aus dem Besucher-Umschalter auszublenden. Die Standardpalette bleibt aktiv. Bleibt nur eine Palette übrig, verschwindet der Umschalter.',
   modeLight: 'Heller Modus',
   modeDark: 'Dunkler Modus',
   colorBg: 'Hintergrund',

--- a/src/locales/admin/en.ts
+++ b/src/locales/admin/en.ts
@@ -142,6 +142,8 @@ const en = {
   themePresetHint: 'Each palette has its own colors. Pick one to edit; visitors can switch palettes on the site and see your edits. Reset restores that palette’s built-in colors.',
   themeDefault: 'Default',
   themeSetDefault: 'Set as default',
+  paletteShown: 'Shown to visitors',
+  paletteVisibilityHint: 'Uncheck a palette to hide it from the visitor switcher. The default stays on. With only one palette left, the switch button disappears.',
   modeLight: 'Light mode',
   modeDark: 'Dark mode',
   colorBg: 'Background',

--- a/src/locales/admin/ja.ts
+++ b/src/locales/admin/ja.ts
@@ -142,6 +142,8 @@ const ja = {
   themePresetHint: 'パレットごとに色が独立しています。編集するパレットを選択。訪問者はサイトでパレットを切り替えでき、編集が反映されます。リセットでそのパレットの初期色に戻します。',
   themeDefault: '既定',
   themeSetDefault: '既定にする',
+  paletteShown: '訪問者に表示',
+  paletteVisibilityHint: 'パレットのチェックを外すと、訪問者の切り替えメニューから非表示になります。既定のパレットは常に有効です。残りが1つだけになると、切り替えボタンは消えます。',
   modeLight: 'ライトモード',
   modeDark: 'ダークモード',
   colorBg: '背景',

--- a/src/locales/admin/ko.ts
+++ b/src/locales/admin/ko.ts
@@ -142,6 +142,8 @@ const ko = {
   themePresetHint: '팔레트마다 색상이 독립적입니다. 편집할 팔레트를 선택하세요. 방문자는 사이트에서 팔레트를 바꿀 수 있고 수정 내용이 반영됩니다. 재설정하면 해당 팔레트의 기본 색상으로 되돌립니다.',
   themeDefault: '기본',
   themeSetDefault: '기본으로 설정',
+  paletteShown: '방문자에게 표시',
+  paletteVisibilityHint: '팔레트의 체크를 해제하면 방문자 전환 메뉴에서 숨겨집니다. 기본 팔레트는 항상 켜져 있습니다. 팔레트가 하나만 남으면 전환 버튼이 사라집니다.',
   modeLight: '라이트 모드',
   modeDark: '다크 모드',
   colorBg: '배경',

--- a/src/locales/admin/vi.ts
+++ b/src/locales/admin/vi.ts
@@ -142,6 +142,8 @@ const vi = {
   themePresetHint: 'Mỗi bảng có màu riêng. Chọn một bảng để sửa; khách có thể đổi bảng ngoài trang và thấy bản bạn đã sửa. Đặt lại sẽ về màu gốc của bảng đó.',
   themeDefault: 'Mặc định',
   themeSetDefault: 'Đặt làm mặc định',
+  paletteShown: 'Hiện cho khách',
+  paletteVisibilityHint: 'Bỏ chọn một bảng để ẩn nó khỏi nút đổi bảng của khách. Bảng mặc định luôn bật. Khi chỉ còn một bảng, nút đổi giao diện sẽ biến mất.',
   modeLight: 'Chế độ sáng',
   modeDark: 'Chế độ tối',
   colorBg: 'Nền',

--- a/src/locales/admin/zh.ts
+++ b/src/locales/admin/zh.ts
@@ -142,6 +142,8 @@ const zh = {
   themePresetHint: '每个配色都有独立颜色。选择要编辑的配色；访客可在站点切换配色并看到你的修改。重置将恢复该配色的内置颜色。',
   themeDefault: '默认',
   themeSetDefault: '设为默认',
+  paletteShown: '对访客显示',
+  paletteVisibilityHint: '取消勾选某个配色，即可在访客的切换菜单中隐藏它。默认配色始终保留。仅剩一个配色时，切换按钮会消失。',
   modeLight: '浅色模式',
   modeDark: '深色模式',
   colorBg: '背景',

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -203,6 +203,8 @@ export type AdminStrings = {
   themePresetHint: string
   themeDefault: string
   themeSetDefault: string
+  paletteShown: string
+  paletteVisibilityHint: string
   modeLight: string
   modeDark: string
   colorBg: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -176,6 +176,7 @@ export type SiteSettings = {
   customCss: string // owner CSS injected into PUBLIC pages only ('' = none)
   menu: MenuItem[] // header navigation links
   themePreset: string // default palette for visitors (one of THEME_PRESETS ids)
+  enabledPalettes: string[] // palettes a visitor may switch between (subset of THEME_PRESETS ids); ALWAYS includes themePreset. <2 enabled => the switcher is hidden
   themes: Record<string, ThemeSettings> // per-palette reading colors (owner-customizable); keyed by preset id
   typography: TypographySettings // type scale + reading rhythm → CSS vars (--fs-*, --lh-body, --ls-body)
   customFont: FontSettings // owner-uploaded typeface (Blob files/); '' = bundled Inter


### PR DESCRIPTION
## What
Owner can turn each color palette (color scheme) on/off for visitors, and when only **one** palette is enabled the theme-switch icon disappears entirely.

## Changes
- **`settings.enabledPalettes`** — allow-list of preset ids a visitor may switch between. Default = all on; **always includes the default palette** so it's never empty.
- **Admin → Appearance**: a "Shown to visitors" checkbox per palette card (default palette locked on). Disabled palettes stay fully editable.
- **Public + admin switcher**: `enabledPaletteOptions()` filters the list; `PaletteToggle` renders `null` when ≤1 option → no icon.
- **No-FOUC**: ignores a stored palette that's no longer enabled (falls back to default, no flash).
- **Migration-safe**: legacy settings without the field read as "all on" (`sanitizeEnabledPalettes`).
- i18n: 6 admin locales synced (`paletteShown`, `paletteVisibilityHint`).
- Docs: CHANGELOG + `docs/features.md`. Test: `settings-sanitize.test.ts`.

## Verify
`npm run check:all` green (66 tests) · `npm run build` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)