### PR TITLE
fix(comments): too-deep reply returns 400, not 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 2026-06-23 (v1.1.0-beta — comments: a too-deep reply is a clean 400, not a 500)
+- **fix(comments): replying past the 3-tier limit (or to a missing parent) now returns 400, not
+  500.** Found in a live end-to-end pass on manhhung.me — the depth guard worked but `addComment`
+  threw a generic `Error` that fell through to the 500 handler. It now throws a typed
+  `CommentInputError` the route maps to 400 with a clear message. Pinned by `comments.test.ts`
+  (depth-limit / missing-parent / empty-body guards). `v1.1.0-beta`.
+
 ## 2026-06-23 (v1.1.0-beta — comment integration keys move into the admin)
 - **feat: Turnstile + Facebook keys are entered in Admin → Settings, not env.** The optional comment
   integrations no longer need a Vercel redeploy to configure. Keys are SECRETS, kept in a new

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -8,7 +8,7 @@
 
 import type { NextRequest } from 'next/server'
 import { after } from 'next/server'
-import { getCommentTree, addComment, MAX_COMMENT_LEN } from '@/lib/comments'
+import { getCommentTree, addComment, CommentInputError, MAX_COMMENT_LEN } from '@/lib/comments'
 import { getPost } from '@/lib/posts'
 import { getSettings } from '@/lib/settings'
 import { getCommenter } from '@/lib/auth'
@@ -114,7 +114,14 @@ export async function POST(req: NextRequest): Promise<Response> {
       identity = { name, email, website, provider: 'manual' }
     }
 
-    const created = await addComment({ postSlug, parentId, ...identity, content })
+    let created
+    try {
+      created = await addComment({ postSlug, parentId, ...identity, content })
+    } catch (error) {
+      // Bad input (missing parent, too-deep reply) → 400, not a 500.
+      if (error instanceof CommentInputError) return fail(error.message, 400)
+      throw error
+    }
     after(() => logActivity('comment.create', postSlug))
     logRequest(req, 200, start)
     return ok({ comment: created })

--- a/src/lib/comments.test.ts
+++ b/src/lib/comments.test.ts
@@ -1,5 +1,28 @@
-import { describe, it, expect } from 'vitest'
-import { buildCommentTree, type CommentRow } from '@/lib/comments'
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock the data layer so addComment's parent lookup is controllable. `liveOnly`
+// is a pass-through; `insert` returns a minimal row (only reached on success).
+const hoisted = vi.hoisted(() => ({
+  parent: null as { post_slug: string; depth: number; deleted_at: string | null } | null,
+}))
+vi.mock('@/lib/db', () => ({
+  liveOnly: <T>(q: T): T => q,
+  db: () => ({
+    from: () => ({
+      select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: hoisted.parent }) }) }),
+      insert: () => ({
+        select: () => ({
+          single: () =>
+            Promise.resolve({
+              data: { id: 9, parent_id: 1, author_name: 'x', author_website: null, provider: 'manual', content: 'c', created_at: 't', deleted_at: null },
+            }),
+        }),
+      }),
+    }),
+  }),
+}))
+
+import { buildCommentTree, addComment, CommentInputError, type CommentRow } from '@/lib/comments'
 
 // Build a row with sane defaults; override what each case needs.
 function row(p: Partial<CommentRow> & { id: number }): CommentRow {
@@ -56,5 +79,23 @@ describe('buildCommentTree', () => {
     // id 2 references parent 99 which is not in the set -> treated as a root.
     const tree = buildCommentTree([row({ id: 1 }), row({ id: 2, parent_id: 99, depth: 1 })])
     expect(tree.map((c) => c.id).sort()).toEqual([1, 2])
+  })
+})
+
+describe('addComment input guards', () => {
+  const base = { postSlug: 'hello', name: 'A', email: 'a@b.co', provider: 'manual' as const, content: 'hi' }
+
+  it('rejects a reply past the 3-tier limit with a CommentInputError', async () => {
+    hoisted.parent = { post_slug: 'hello', depth: 2, deleted_at: null } // already at the deepest tier
+    await expect(addComment({ ...base, parentId: 1 })).rejects.toBeInstanceOf(CommentInputError)
+  })
+
+  it('rejects a reply to a missing/deleted parent', async () => {
+    hoisted.parent = null
+    await expect(addComment({ ...base, parentId: 1 })).rejects.toBeInstanceOf(CommentInputError)
+  })
+
+  it('rejects empty content', async () => {
+    await expect(addComment({ ...base, parentId: null, content: '   ' })).rejects.toBeInstanceOf(CommentInputError)
   })
 })

--- a/src/lib/comments.ts
+++ b/src/lib/comments.ts
@@ -11,6 +11,10 @@ import { renderCommentMarkdown } from '@/lib/comment-md'
 export const MAX_COMMENT_LEN = 1000
 const MAX_DEPTH = 2 // depth 0,1,2 => 3 reply tiers
 
+// Bad-input errors from addComment (empty body, missing parent, too-deep reply).
+// The route maps these to 400; anything else is a real 500.
+export class CommentInputError extends Error {}
+
 // A row as stored (snake_case). Email is selected ONLY by admin reads.
 export type CommentRow = {
   id: number
@@ -107,7 +111,7 @@ export type NewComment = {
 // Returns the new node ready to render (single, no replies). Throws on bad input.
 export async function addComment(input: NewComment): Promise<PublicComment> {
   const content = input.content.trim().slice(0, MAX_COMMENT_LEN)
-  if (!content) throw new Error('empty content')
+  if (!content) throw new CommentInputError('Comment cannot be empty')
 
   let depth = 0
   let postSlug = input.postSlug
@@ -118,8 +122,8 @@ export async function addComment(input: NewComment): Promise<PublicComment> {
       .eq('id', input.parentId)
       .maybeSingle()
     const p = parent as Pick<CommentRow, 'post_slug' | 'depth' | 'deleted_at'> | null
-    if (!p || p.deleted_at !== null) throw new Error('parent not found')
-    if (p.depth >= MAX_DEPTH) throw new Error('max reply depth reached')
+    if (!p || p.deleted_at !== null) throw new CommentInputError('Comment not found')
+    if (p.depth >= MAX_DEPTH) throw new CommentInputError('Maximum reply depth reached')
     depth = p.depth + 1
     postSlug = p.post_slug // a reply always belongs to the parent's post
   }


### PR DESCRIPTION
Found while doing a live end-to-end check of the comment system on manhhung.me.

**Bug:** replying past the 3-tier limit (or to a deleted/missing parent) was correctly **blocked**, but the API returned **500** — `addComment` threw a generic `Error` that fell through to the 500 handler.

**Fix:** `addComment` now throws a typed `CommentInputError` for bad input (empty body, missing parent, too-deep reply); the route maps it to **400** with the message. Pinned by `comments.test.ts` (3 new guards).

Everything else in the live pass was correct: GET empty, manual POST creates + renders limited markdown, `<script>` escaped, bad email / empty content → 400, 3-tier threading nests right. `check:all` green · `build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)