### PR TITLE
feat(blog): rework post ToC — "Tiêu đề" title, in-page jumps, mobile slide-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 2026-06-23 (v1.1.0-beta — ToC panel: "Tiêu đề", in-page jumps, mobile slide-out)
+- **feat(blog): the post ToC is reworked.** Its title is now **"Tiêu đề"** (Headings) instead of
+  "Mục lục"/"Contents" in all 6 locales, and **clicking the title scrolls back to the top**. Under
+  the heading list it now links to the **in-page tags / categories / comments** (scroll-only, via a
+  shared `TOC_ANCHORS` map + `scroll-mt-24` targets on those blocks). Desktop keeps the left-pinned,
+  always-visible panel; **mobile now gets it too** — hidden by default behind a left-edge tab that
+  slides the panel out over the content. The panel now has a solid `bg-bg` background (+ shadow on
+  mobile) so it always sits cleanly over the content instead of letting text show through. `v1.1.0-beta`.
+
 ## 2026-06-23 (v1.1.0-beta — comment integrations: setup help + links in the admin)
 - **feat(admin): each comment integration now shows a one-line setup guide + a link.** Turnstile →
   Cloudflare dashboard; Facebook → Meta for Developers (create app, add Facebook Login, redirect

--- a/docs/features.md
+++ b/docs/features.md
@@ -30,9 +30,11 @@
   `searchPosts` `.textSearch('search', …, {config:'simple'})`). **NOTE:** `simple` is accent-
   *sensitive* — accent-insensitivity comes from the local layer only. Header search =
   `SearchOverlay` (modal); the `/search` route stays for deep links / no-JS.
-- Post page: `ReadingProgress`, `BackToTop`, `Toc` (≥3 H2/H3; desktop-only, sticky in the
-  left gutter; `PostContent` assigns slug ids), `RelatedPosts` (`getRelatedPosts`: shared
-  tags ×2 + categories).
+- Post page: `ReadingProgress`, `BackToTop`, `Toc` (≥3 H2/H3; title click scrolls to top;
+  under the headings it links to the in-page tags/categories/comments via `TOC_ANCHORS`;
+  left-pinned + always visible on desktop, hidden behind a left-edge tab + slide-out on
+  mobile; solid `bg-bg` so it never shows content through; `PostContent` assigns slug ids),
+  `RelatedPosts` (`getRelatedPosts`: shared tags ×2 + categories).
 - **GOTCHA:** the global unlayered `hr { margin:0 }` beats Tailwind margin utilities — put
   divider spacing on a wrapper div, not on the `<hr>`.
 - **Heading ids are de-duped** (2nd `foo` → `foo-2`): `dedupeHeadingIds` (PostContent) and

--- a/src/app/(blog)/[slug]/page.tsx
+++ b/src/app/(blog)/[slug]/page.tsx
@@ -13,7 +13,7 @@ import { getSettings, resolveSiteUrl } from '@/lib/settings'
 import { formatDate, t } from '@/lib/i18n'
 import { PostContent } from '@/components/blog/PostContent'
 import { JsonLd, articleSchema } from '@/components/blog/JsonLd'
-import { Toc } from '@/components/blog/Toc'
+import { Toc, TOC_ANCHORS } from '@/components/blog/Toc'
 import { ReadingProgress } from '@/components/blog/ReadingProgress'
 import { BackToTop } from '@/components/blog/BackToTop'
 import { ScrollDepth } from '@/components/blog/ScrollDepth'
@@ -102,6 +102,14 @@ export default async function EntryPage({ params }: PageProps<'/[slug]'>) {
     const related = features.related ? await getRelatedPosts(post.slug, settings.relatedCount) : []
     const commentEnv = settings.comments.enabled ? await getCommentEnv() : null
     const hasTaxo = post.tags.length > 0 || post.categories.length > 0
+    const showComments = Boolean(settings.comments.enabled && commentEnv)
+    // In-page jumps shown under the ToC headings (only for sections present here).
+    const tx = t(language)
+    const tocJumps = [
+      post.tags.length > 0 ? { id: TOC_ANCHORS.tags, label: tx.tagLabel } : null,
+      post.categories.length > 0 ? { id: TOC_ANCHORS.categories, label: tx.categoryLabel } : null,
+      showComments ? { id: TOC_ANCHORS.comments, label: tx.commentsHeading } : null,
+    ].filter((j): j is { id: string; label: string } => j !== null)
     return (
       <article>
         {features.progressBar && <ReadingProgress />}
@@ -128,9 +136,10 @@ export default async function EntryPage({ params }: PageProps<'/[slug]'>) {
           {features.readingTime && ` · ${minutes} ${t(language).readingSuffix}`}
         </p>
 
-        {/* The desktop ToC is fixed to the viewport (see Toc.tsx), not anchored here. */}
+        {/* The ToC is fixed to the viewport (see Toc.tsx) — left-pinned on desktop,
+            a left-edge tab + slide-out on mobile — not anchored here. */}
         <div className="mt-8">
-          {headings.length >= 3 && <Toc headings={headings} title={t(language).tocTitle} />}
+          {headings.length >= 3 && <Toc headings={headings} title={tx.tocTitle} jumps={tocJumps} />}
           <PostContent markdown={post.content} readyOriginals={readyOriginals} imageDims={imageDims} />
         </div>
 
@@ -143,13 +152,13 @@ export default async function EntryPage({ params }: PageProps<'/[slug]'>) {
             </div>
             <footer className="mt-6 space-y-1 t-small text-meta">
               {post.tags.length > 0 && (
-                <p>
-                  {t(language).tagLabel}: {taxoLinks(post.tags, (s) => `/tag/${termSlug(s)}`)}
+                <p id={TOC_ANCHORS.tags} className="scroll-mt-24">
+                  {tx.tagLabel}: {taxoLinks(post.tags, (s) => `/tag/${termSlug(s)}`)}
                 </p>
               )}
               {post.categories.length > 0 && (
-                <p>
-                  {t(language).categoryLabel}: {taxoLinks(post.categories, (s) => `/category/${termSlug(s)}`)}
+                <p id={TOC_ANCHORS.categories} className="scroll-mt-24">
+                  {tx.categoryLabel}: {taxoLinks(post.categories, (s) => `/category/${termSlug(s)}`)}
                 </p>
               )}
             </footer>
@@ -169,9 +178,9 @@ export default async function EntryPage({ params }: PageProps<'/[slug]'>) {
           </>
         )}
 
-        {settings.comments.enabled && commentEnv && (
+        {showComments && commentEnv && (
           <>
-            <div className="mt-12">
+            <div id={TOC_ANCHORS.comments} className="mt-12 scroll-mt-24">
               <hr />
             </div>
             <Comments

--- a/src/components/blog/Toc.tsx
+++ b/src/components/blog/Toc.tsx
@@ -2,11 +2,31 @@
 
 // Table of contents for a post. Renders at the top of long articles (>= 3
 // headings). Highlights the section currently in view and scrolls smoothly.
+// Below the headings it links to the in-page tags / categories / comments.
+// Desktop (xl+): pinned to the left of the viewport, always visible.
+// Mobile (< xl): hidden by default behind a left-edge tab; tapping the tab
+// slides the panel out over the content (solid background, so nothing shows
+// through), tapping outside or an item closes it again.
 import { useEffect, useState } from 'react'
 import type { Heading } from '@/lib/utils'
 
-export function Toc({ headings, title }: { headings: Heading[]; title: string }) {
+// In-page anchors the panel jumps to (set on the matching blocks in the post page).
+export const TOC_ANCHORS = { tags: 'post-tags', categories: 'post-categories', comments: 'post-comments' }
+
+type Jump = { id: string; label: string }
+
+export function Toc({
+  headings,
+  title,
+  jumps,
+}: {
+  headings: Heading[]
+  title: string
+  // Optional in-page jumps (tags / categories / comments) shown under the headings.
+  jumps: Jump[]
+}) {
   const [active, setActive] = useState<string>('')
+  const [open, setOpen] = useState(false) // mobile slide-out state only
 
   useEffect(() => {
     const els = headings
@@ -24,40 +44,110 @@ export function Toc({ headings, title }: { headings: Heading[]; title: string })
     return () => obs.disconnect()
   }, [headings])
 
-  function go(e: React.MouseEvent, id: string) {
+  // Close the mobile panel on Escape.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setOpen(false)
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open])
+
+  function goId(e: React.MouseEvent, id: string) {
     e.preventDefault()
     const el = document.getElementById(id)
     if (!el) return
     el.scrollIntoView({ behavior: 'smooth', block: 'start' })
     history.replaceState(null, '', `#${id}`)
+    setOpen(false)
   }
 
-  return (
-    // Desktop only (xl+). Pinned to the LEFT EDGE OF THE VIEWPORT (50px in), not to
-    // the content column — the whole blog is a centered max-width box, so anchoring
-    // to the column left put the ToC in a narrow gutter where wide/full-bleed images
-    // overlapped it. `fixed` + viewport-left keeps it hard left, clear of content.
-    // Vertically centred (top-1/2 + -translate-y-1/2) so it never collides with the
-    // header or footer; `max-h`/scroll handles long lists. Title + items flush left.
-    <div className="fixed top-1/2 left-[50px] z-10 hidden w-60 -translate-y-1/2 xl:block">
-      <nav aria-label={title} className="max-h-[80vh] overflow-y-auto rounded-xl border border-rule p-5 t-small">
-        <p className="mb-2 font-semibold text-heading">{title}</p>
-        <ul className="space-y-1.5">
-          {headings.map((h) => (
-            <li key={h.id}>
+  // Clicking the title scrolls back up to the top of the post.
+  function goTop(e: React.MouseEvent) {
+    e.preventDefault()
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+    history.replaceState(null, '', location.pathname)
+    setOpen(false)
+  }
+
+  const inner = (
+    <>
+      <button
+        type="button"
+        onClick={goTop}
+        className="mb-2 block text-left font-semibold text-heading transition-opacity hover:opacity-70"
+      >
+        {title}
+      </button>
+      <ul className="space-y-1.5">
+        {headings.map((h) => (
+          <li key={h.id}>
+            <a
+              href={`#${h.id}`}
+              onClick={(e) => goId(e, h.id)}
+              className={`block transition-colors hover:text-heading ${
+                active === h.id ? 'font-medium text-heading' : 'text-meta'
+              }`}
+            >
+              {h.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+      {jumps.length > 0 && (
+        <ul className="mt-4 space-y-1.5">
+          {jumps.map((j) => (
+            <li key={j.id}>
               <a
-                href={`#${h.id}`}
-                onClick={(e) => go(e, h.id)}
-                className={`block transition-colors hover:text-heading ${
-                  active === h.id ? 'font-medium text-heading' : 'text-meta'
-                }`}
+                href={`#${j.id}`}
+                onClick={(e) => goId(e, j.id)}
+                className="block text-meta transition-colors hover:text-heading"
               >
-                {h.text}
+                {j.label}
               </a>
             </li>
           ))}
         </ul>
-      </nav>
-    </div>
+      )}
+    </>
+  )
+
+  // Solid background + border so the panel always sits cleanly over the content.
+  const navClass =
+    'max-h-[80vh] overflow-y-auto rounded-xl border border-rule bg-bg p-5 t-small'
+
+  return (
+    <>
+      {/* Mobile (< xl): left-edge tab, then slide-out panel over the content. */}
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label={title}
+        aria-expanded={open}
+        className="fixed top-1/2 left-0 z-20 -translate-y-1/2 rounded-r-lg border border-l-0 border-rule bg-bg px-2 py-4 text-meta transition-opacity hover:opacity-70 xl:hidden"
+      >
+        <span className="t-small [writing-mode:vertical-rl]">{title}</span>
+      </button>
+
+      {open && (
+        // Transparent full-screen catcher closes on outside tap (no dim, so we
+        // never hardcode a non-token colour).
+        <div className="fixed inset-0 z-30 xl:hidden" onClick={() => setOpen(false)}>
+          <nav
+            aria-label={title}
+            onClick={(e) => e.stopPropagation()}
+            className={`${navClass} absolute top-1/2 left-0 w-64 -translate-y-1/2 border-l-0 shadow-lg`}
+          >
+            {inner}
+          </nav>
+        </div>
+      )}
+
+      {/* Desktop (xl+): pinned to the left edge of the viewport, always visible. */}
+      <div className="fixed top-1/2 left-[50px] z-10 hidden w-60 -translate-y-1/2 xl:block">
+        <nav aria-label={title} className={navClass}>
+          {inner}
+        </nav>
+      </div>
+    </>
   )
 }

--- a/src/locales/admin/de.ts
+++ b/src/locales/admin/de.ts
@@ -237,7 +237,7 @@ const de = {
   featSearch: 'Suche',
   featSearchDesc: 'Such-Symbol im Header und die Seite /search.',
   featToc: 'Inhaltsverzeichnis',
-  featTocDesc: 'Linkes Inhaltsverzeichnis (Desktop) für Beiträge mit 3+ Überschriften.',
+  featTocDesc: 'Linkes Überschriften-Panel für Beiträge mit 3+ Überschriften; auf Mobil hinter einem Rand-Tab einklappbar.',
   featRelated: 'Ähnliche Beiträge',
   featRelatedDesc: 'Schlägt am Ende Beiträge mit gleichen Schlagwörtern/Kategorien vor.',
   featReadingTime: 'Lesezeit',

--- a/src/locales/admin/en.ts
+++ b/src/locales/admin/en.ts
@@ -237,7 +237,7 @@ const en = {
   featSearch: 'Search',
   featSearchDesc: 'Search icon in the header and the /search page.',
   featToc: 'Table of contents',
-  featTocDesc: 'Left-side ToC (desktop) for posts with 3+ headings.',
+  featTocDesc: 'Left-side headings panel for posts with 3+ headings; collapsible behind an edge tab on mobile.',
   featRelated: 'Related posts',
   featRelatedDesc: 'Suggests posts sharing tags/categories at the end.',
   featReadingTime: 'Reading time',

--- a/src/locales/admin/ja.ts
+++ b/src/locales/admin/ja.ts
@@ -237,7 +237,7 @@ const ja = {
   featSearch: '検索',
   featSearchDesc: 'ヘッダーの検索アイコンと /search ページ。',
   featToc: '目次',
-  featTocDesc: '見出しが3つ以上の記事に左側の目次（デスクトップ）を表示。',
+  featTocDesc: '見出しが3つ以上の記事に左側の見出しパネルを表示。モバイルでは端のタブに格納。',
   featRelated: '関連記事',
   featRelatedDesc: '記事の末尾に同じタグ/カテゴリーの記事を提案。',
   featReadingTime: '読了時間',

--- a/src/locales/admin/ko.ts
+++ b/src/locales/admin/ko.ts
@@ -237,7 +237,7 @@ const ko = {
   featSearch: '검색',
   featSearchDesc: '헤더의 검색 아이콘과 /search 페이지.',
   featToc: '목차',
-  featTocDesc: '제목이 3개 이상인 게시물에 왼쪽 목차 표시(데스크톱).',
+  featTocDesc: '제목이 3개 이상인 게시물에 왼쪽 제목 패널 표시; 모바일에서는 가장자리 탭에 접힘.',
   featRelated: '관련 게시물',
   featRelatedDesc: '게시물 끝에 같은 태그/카테고리의 글을 추천합니다.',
   featReadingTime: '읽기 시간',

--- a/src/locales/admin/vi.ts
+++ b/src/locales/admin/vi.ts
@@ -237,7 +237,7 @@ const vi = {
   featSearch: 'Tìm kiếm',
   featSearchDesc: 'Icon tìm trên header và trang /search.',
   featToc: 'Mục lục',
-  featTocDesc: 'Khung mục lục bên trái (desktop) cho bài có từ 3 đề mục.',
+  featTocDesc: 'Khung tiêu đề bên trái cho bài có từ 3 đề mục; trên mobile ẩn sau tab mép trái.',
   featRelated: 'Bài viết liên quan',
   featRelatedDesc: 'Gợi ý bài cùng thẻ/danh mục ở cuối bài.',
   featReadingTime: 'Thời gian đọc',

--- a/src/locales/admin/zh.ts
+++ b/src/locales/admin/zh.ts
@@ -237,7 +237,7 @@ const zh = {
   featSearch: '搜索',
   featSearchDesc: '页眉的搜索图标和 /search 页面。',
   featToc: '目录',
-  featTocDesc: '为有 3 个以上标题的文章显示左侧目录（桌面端）。',
+  featTocDesc: '为有 3 个以上标题的文章显示左侧标题面板；移动端收纳在边缘标签后。',
   featRelated: '相关文章',
   featRelatedDesc: '在文末推荐相同标签/分类的文章。',
   featReadingTime: '阅读时间',

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -20,7 +20,7 @@ const de = {
   searchPlaceholder: 'Beiträge suchen...',
   searchHint: 'Tippen, um Beiträge zu suchen.',
   searchEmpty: 'Keine passenden Beiträge gefunden.',
-  tocTitle: 'Inhalt',
+  tocTitle: 'Überschriften',
   relatedTitle: 'Ähnliche Beiträge',
   notFoundTitle: 'Seite nicht gefunden',
   notFoundText: 'Die gesuchte Seite existiert nicht oder wurde verschoben.',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -20,7 +20,7 @@ const en = {
   searchPlaceholder: 'Search posts...',
   searchHint: 'Type to search posts.',
   searchEmpty: 'No matching posts found.',
-  tocTitle: 'Contents',
+  tocTitle: 'Headings',
   relatedTitle: 'Related posts',
   notFoundTitle: 'Page not found',
   notFoundText: 'The page you are looking for does not exist or has moved.',

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -20,7 +20,7 @@ const ja = {
   searchPlaceholder: '投稿を検索...',
   searchHint: 'キーワードを入力して投稿を検索します。',
   searchEmpty: '一致する投稿が見つかりません。',
-  tocTitle: '目次',
+  tocTitle: '見出し',
   relatedTitle: '関連記事',
   notFoundTitle: 'ページが見つかりません',
   notFoundText: 'お探しのページは存在しないか、移動されました。',

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -20,7 +20,7 @@ const ko = {
   searchPlaceholder: '게시물 검색...',
   searchHint: '키워드를 입력해 게시물을 검색하세요.',
   searchEmpty: '일치하는 게시물이 없습니다.',
-  tocTitle: '목차',
+  tocTitle: '제목',
   relatedTitle: '관련 게시물',
   notFoundTitle: '페이지를 찾을 수 없습니다',
   notFoundText: '찾으시는 페이지가 존재하지 않거나 이동되었습니다.',

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -20,7 +20,7 @@ const vi = {
   searchPlaceholder: 'Tìm bài viết...',
   searchHint: 'Nhập từ khoá để tìm bài viết.',
   searchEmpty: 'Không tìm thấy bài viết phù hợp.',
-  tocTitle: 'Mục lục',
+  tocTitle: 'Tiêu đề',
   relatedTitle: 'Bài viết liên quan',
   notFoundTitle: 'Không tìm thấy trang',
   notFoundText: 'Trang bạn tìm không tồn tại hoặc đã được dời đi.',

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -20,7 +20,7 @@ const zh = {
   searchPlaceholder: '搜索文章...',
   searchHint: '输入关键词搜索文章。',
   searchEmpty: '未找到匹配的文章。',
-  tocTitle: '目录',
+  tocTitle: '标题',
   relatedTitle: '相关文章',
   notFoundTitle: '页面未找到',
   notFoundText: '您查找的页面不存在或已被移动。',


### PR DESCRIPTION
## What

Reworks the single-post Table of Contents panel.

- **Title is now "Tiêu đề"** (was "Mục lục"/"Contents") in all 6 locales; **clicking the title scrolls back to the top** of the post.
- Under the headings, the panel links to the **in-page tags / categories / comments** (scroll-only) via a shared `TOC_ANCHORS` map + `scroll-mt-24` targets on those blocks.
- **Mobile support added:** hidden by default behind a **left-edge tab**; tapping it slides the panel out over the content. Closes on Escape / outside-tap / item-tap. Desktop behaviour is unchanged (left-pinned, always visible).
- Panel now has a **solid `bg-bg` background** (+ shadow on mobile) so it always sits cleanly over the content instead of letting text show through.

## Verify

- `npm run check:all` ✓ (typecheck + lint + guards + 81 tests; only a pre-existing ThemeFields warning)
- `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)