### PR TITLE
fix(blog): ToC round 2 — "Mục lục" for heading-less posts, comment count, cursors, wider phone gutters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@
   the first existing section (scroll-only, via a shared `TOC_ANCHORS` map + `scroll-mt-24` targets).
   The panel is now **collapsible on every viewport** from a **text-free left-edge handle** (the tab
   shape speaks for itself): default **open + pinned on desktop**, default **closed on mobile**
-  (outside-tap / Escape dismiss). It renders **nothing when the post has no headings**, has a solid
-  `bg-bg` background so it never shows content through, and mobile gains a touch more side margin
-  (`px-6`). `v1.1.0-beta`.
+  (outside-tap / Escape dismiss). When a post has **no headings** the header is a plain,
+  non-clickable **"Mục lục"** (`tocIndex`) and only the jump line shows; the panel disappears only
+  when there is nothing at all to show. The **comments** label carries its **count in front**
+  (e.g. "12 Bình luận", server-rendered). Solid `bg-bg` background so it never shows content
+  through; clickable items now get a pointer cursor; phones gain wider side gutters
+  (`px-8 sm:px-5`) so the handle clears the text. `v1.1.0-beta`.
 
 ## 2026-06-23 (v1.1.0-beta — comment integrations: setup help + links in the admin)
 - **feat(admin): each comment integration now shows a one-line setup guide + a link.** Turnstile →

--- a/docs/features.md
+++ b/docs/features.md
@@ -30,13 +30,16 @@
   `searchPosts` `.textSearch('search', …, {config:'simple'})`). **NOTE:** `simple` is accent-
   *sensitive* — accent-insensitivity comes from the local layer only. Header search =
   `SearchOverlay` (modal); the `/search` route stays for deep links / no-JS.
-- Post page: `ReadingProgress`, `BackToTop`, `Toc` (≥3 H2/H3 — also `return null` if no
-  headings; title click scrolls to top; ONE line under the headings joins the present
-  tags/categories/comments labels and jumps to the first existing section via `TOC_ANCHORS`;
-  collapsible on every viewport from a text-free left-edge handle — default open + pinned on
-  desktop (xl+), default closed + outside-tap/Escape-dismissable on mobile; solid `bg-bg` so it
-  never shows content through; `PostContent` assigns slug ids), `RelatedPosts`
-  (`getRelatedPosts`: shared tags ×2 + categories).
+- Post page: `ReadingProgress`, `BackToTop`, `Toc`, `RelatedPosts` (`getRelatedPosts`: shared
+  tags ×2 + categories).
+- `Toc` shows whenever a post has headings OR an in-page jump (`showToc` in the page; renders
+  nothing otherwise). Header: clickable **"Tiêu đề"** (`tocTitle`) that scrolls to top when there
+  ARE headings, else a plain non-clickable **"Mục lục"** (`tocIndex`). One line under it joins the
+  present tags/categories/comments labels (comments prefixed with their server-rendered count) and
+  jumps to the first existing section via `TOC_ANCHORS` + `scroll-mt-24` targets. Collapsible on
+  every viewport from a text-free left-edge handle — default open + pinned on desktop (xl+), default
+  closed + outside-tap/Escape-dismissable on mobile. Solid `bg-bg`; `PostContent` assigns slug ids.
+  Phones get wider side gutters (`px-8 sm:px-5`) so the handle clears the text.
 - **GOTCHA:** the global unlayered `hr { margin:0 }` beats Tailwind margin utilities — put
   divider spacing on a wrapper div, not on the `<hr>`.
 - **Heading ids are de-duped** (2nd `foo` → `foo-2`): `dedupeHeadingIds` (PostContent) and

--- a/src/app/(blog)/[slug]/page.tsx
+++ b/src/app/(blog)/[slug]/page.tsx
@@ -20,6 +20,7 @@ import { ScrollDepth } from '@/components/blog/ScrollDepth'
 import { RelatedPosts } from '@/components/blog/RelatedPosts'
 import { Comments } from '@/components/blog/Comments'
 import { getCommentEnv } from '@/lib/comment-env'
+import { countsByPosts } from '@/lib/comments'
 import { ogImageUrl } from '@/lib/og'
 import { isPublicallyVisible, readingMinutes, extractHeadings, extractImageUrls } from '@/lib/utils'
 
@@ -104,12 +105,14 @@ export default async function EntryPage({ params }: PageProps<'/[slug]'>) {
     const hasTaxo = post.tags.length > 0 || post.categories.length > 0
     const showComments = Boolean(settings.comments.enabled && commentEnv)
     // ONE in-page jump under the ToC headings: the present section labels joined
-    // (Thẻ / Danh mục / Bình luận), scrolling to the first section that exists.
+    // (Thẻ / Danh mục / N Bình luận), scrolling to the first section that exists.
+    // The comment count is server-rendered (count as of this render).
     const tx = t(language)
+    const commentCount = showComments ? (await countsByPosts())[post.slug] ?? 0 : 0
     const metaParts = [
       post.tags.length > 0 ? tx.tagLabel : null,
       post.categories.length > 0 ? tx.categoryLabel : null,
-      showComments ? tx.commentsHeading : null,
+      showComments ? (commentCount > 0 ? `${commentCount} ${tx.commentsHeading}` : tx.commentsHeading) : null,
     ].filter((p): p is string => p !== null)
     const metaAnchor = post.tags.length > 0
       ? TOC_ANCHORS.tags
@@ -117,6 +120,8 @@ export default async function EntryPage({ params }: PageProps<'/[slug]'>) {
         ? TOC_ANCHORS.categories
         : TOC_ANCHORS.comments
     const tocMeta = metaParts.length ? { label: metaParts.join(' / '), anchor: metaAnchor } : undefined
+    // Show the panel for any post that has headings to list OR an in-page jump.
+    const showToc = features.toc && (headings.length > 0 || Boolean(tocMeta))
     return (
       <article>
         {features.progressBar && <ReadingProgress />}
@@ -146,7 +151,7 @@ export default async function EntryPage({ params }: PageProps<'/[slug]'>) {
         {/* The ToC is fixed to the viewport (see Toc.tsx) — left-pinned on desktop,
             a left-edge tab + slide-out on mobile — not anchored here. */}
         <div className="mt-8">
-          {headings.length >= 3 && <Toc headings={headings} title={tx.tocTitle} meta={tocMeta} />}
+          {showToc && <Toc headings={headings} title={tx.tocTitle} indexTitle={tx.tocIndex} meta={tocMeta} />}
           <PostContent markdown={post.content} readyOriginals={readyOriginals} imageDims={imageDims} />
         </div>
 

--- a/src/app/(blog)/layout.tsx
+++ b/src/app/(blog)/layout.tsx
@@ -15,7 +15,7 @@ export default async function BlogLayout({ children }: { children: React.ReactNo
   const showLogo = settings.showLogo && settings.logoUrl
   return (
     <div
-      className="mx-auto flex min-h-screen w-full flex-col px-6"
+      className="mx-auto flex min-h-screen w-full flex-col px-8 sm:px-5"
       style={{ maxWidth: settings.contentWidth }}
     >
       {/* Owner CSS, public pages only (admin is never touched). Sanitized in settings.ts. */}

--- a/src/components/blog/Toc.tsx
+++ b/src/components/blog/Toc.tsx
@@ -16,10 +16,12 @@ export const TOC_ANCHORS = { tags: 'post-tags', categories: 'post-categories', c
 export function Toc({
   headings,
   title,
+  indexTitle,
   meta,
 }: {
   headings: Heading[]
-  title: string
+  title: string // header shown when there ARE headings (click scrolls to top)
+  indexTitle: string // header shown when there are NO headings (plain, not clickable)
   // The combined tags/categories/comments jump (label already joined), if any present.
   meta?: { label: string; anchor: string }
 }) {
@@ -63,8 +65,8 @@ export function Toc({
     return () => window.removeEventListener('keydown', onKey)
   }, [open, pinned])
 
-  // No headings → no panel at all (defence in depth; the page already gates on >= 3).
-  if (!headings.length) return null
+  // Nothing to show at all → no panel (the page gates the same way).
+  if (!headings.length && !meta) return null
 
   function goId(e: React.MouseEvent, id: string) {
     e.preventDefault()
@@ -95,33 +97,43 @@ export function Toc({
             aria-label={title}
             className="max-h-[80vh] w-60 overflow-y-auto rounded-r-xl border border-l-0 border-rule bg-bg p-5 t-small shadow-lg"
           >
-            <button
-              type="button"
-              onClick={goTop}
-              className="mb-2 block text-left font-semibold text-heading transition-opacity hover:opacity-70"
-            >
-              {title}
-            </button>
-            <ul className="space-y-1.5">
-              {headings.map((h) => (
-                <li key={h.id}>
-                  <a
-                    href={`#${h.id}`}
-                    onClick={(e) => goId(e, h.id)}
-                    className={`block transition-colors hover:text-heading ${
-                      active === h.id ? 'font-medium text-heading' : 'text-meta'
-                    }`}
-                  >
-                    {h.text}
-                  </a>
-                </li>
-              ))}
-            </ul>
+            {headings.length > 0 ? (
+              // Headings present: clickable header (scrolls to top) + the list.
+              <>
+                <button
+                  type="button"
+                  onClick={goTop}
+                  className="mb-2 block cursor-pointer text-left font-semibold text-heading transition-opacity hover:opacity-70"
+                >
+                  {title}
+                </button>
+                <ul className="space-y-1.5">
+                  {headings.map((h) => (
+                    <li key={h.id}>
+                      <a
+                        href={`#${h.id}`}
+                        onClick={(e) => goId(e, h.id)}
+                        className={`block cursor-pointer transition-colors hover:text-heading ${
+                          active === h.id ? 'font-medium text-heading' : 'text-meta'
+                        }`}
+                      >
+                        {h.text}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </>
+            ) : (
+              // No headings: a plain, non-clickable "Mục lục" header.
+              <p className="mb-2 font-semibold text-heading">{indexTitle}</p>
+            )}
             {meta && (
               <a
                 href={`#${meta.anchor}`}
                 onClick={(e) => goId(e, meta.anchor)}
-                className="mt-4 block text-meta transition-colors hover:text-heading"
+                className={`block cursor-pointer text-meta transition-colors hover:text-heading ${
+                  headings.length > 0 ? 'mt-4' : ''
+                }`}
               >
                 {meta.label}
               </a>
@@ -135,7 +147,7 @@ export function Toc({
           onClick={() => setOpen((o) => !o)}
           aria-label={title}
           aria-expanded={open}
-          className="flex items-center rounded-r-lg border border-l-0 border-rule bg-bg py-5 pr-1 pl-0.5 text-meta transition-colors hover:text-heading"
+          className="flex cursor-pointer items-center rounded-r-lg border border-l-0 border-rule bg-bg py-5 pr-1 pl-0.5 text-meta transition-colors hover:text-heading"
         >
           <svg
             width="14"

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -21,6 +21,7 @@ const de = {
   searchHint: 'Tippen, um Beiträge zu suchen.',
   searchEmpty: 'Keine passenden Beiträge gefunden.',
   tocTitle: 'Überschriften',
+  tocIndex: 'Inhalt',
   relatedTitle: 'Ähnliche Beiträge',
   notFoundTitle: 'Seite nicht gefunden',
   notFoundText: 'Die gesuchte Seite existiert nicht oder wurde verschoben.',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -21,6 +21,7 @@ const en = {
   searchHint: 'Type to search posts.',
   searchEmpty: 'No matching posts found.',
   tocTitle: 'Headings',
+  tocIndex: 'Contents',
   relatedTitle: 'Related posts',
   notFoundTitle: 'Page not found',
   notFoundText: 'The page you are looking for does not exist or has moved.',

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -21,6 +21,7 @@ const ja = {
   searchHint: 'キーワードを入力して投稿を検索します。',
   searchEmpty: '一致する投稿が見つかりません。',
   tocTitle: '見出し',
+  tocIndex: '目次',
   relatedTitle: '関連記事',
   notFoundTitle: 'ページが見つかりません',
   notFoundText: 'お探しのページは存在しないか、移動されました。',

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -21,6 +21,7 @@ const ko = {
   searchHint: '키워드를 입력해 게시물을 검색하세요.',
   searchEmpty: '일치하는 게시물이 없습니다.',
   tocTitle: '제목',
+  tocIndex: '목차',
   relatedTitle: '관련 게시물',
   notFoundTitle: '페이지를 찾을 수 없습니다',
   notFoundText: '찾으시는 페이지가 존재하지 않거나 이동되었습니다.',

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -22,6 +22,7 @@ export type Dict = {
   searchHint: string
   searchEmpty: string
   tocTitle: string
+  tocIndex: string
   relatedTitle: string
   notFoundTitle: string
   notFoundText: string

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -21,6 +21,7 @@ const vi = {
   searchHint: 'Nhập từ khoá để tìm bài viết.',
   searchEmpty: 'Không tìm thấy bài viết phù hợp.',
   tocTitle: 'Tiêu đề',
+  tocIndex: 'Mục lục',
   relatedTitle: 'Bài viết liên quan',
   notFoundTitle: 'Không tìm thấy trang',
   notFoundText: 'Trang bạn tìm không tồn tại hoặc đã được dời đi.',

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -21,6 +21,7 @@ const zh = {
   searchHint: '输入关键词搜索文章。',
   searchEmpty: '未找到匹配的文章。',
   tocTitle: '标题',
+  tocIndex: '目录',
   relatedTitle: '相关文章',
   notFoundTitle: '页面未找到',
   notFoundText: '您查找的页面不存在或已被移动。',


### PR DESCRIPTION
Follow-up to #33 addressing the second review pass.

- **Heading-less posts** now show a plain, **non-clickable "Mục lục"** (`tocIndex`) header + the jump line, instead of hiding the panel. It disappears only when there's nothing at all to show.
- **Comment count in front** of the comments label in the jump line (e.g. "12 Bình luận"), server-rendered via `countsByPosts`.
- **Pointer cursor** on all clickable items (title, headings, jump line, handle) — fixes the missing hand cursor on the title.
- **Wider phone gutters** (`px-8 sm:px-5`) so the edge handle clears the body text; desktop back to original `px-5`.

Note: the jump line is (and was) a real clickable `<a>` that smooth-scrolls to the first present section.

## Verify
- `npm run check:all` ✓ (81 tests; only the pre-existing ThemeFields warning)
- `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)