### PR TITLE
feat(typography): reading-optimized default type scale + remove public hardcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## 2026-06-23 (v1.1.0-beta — reading-optimized typography defaults + remove public hardcode)
+- **change(typography): retuned the default type scale for long-form reading** (the Reset target).
+  Restrained, monotonic heading scale (h1 2.0 → h5 1.0; h5 was 0.9, *below* body — fixed), body
+  leading eased 1.75 → 1.7 for an even grey column, code 1.65 → 1.6, h2 1.4 → 1.5 for clearer
+  hierarchy. ~66-char measure (`contentWidth` 672) kept — already in the 60–75 cpl comfort zone.
+  Updated in BOTH `globals.css :root` and `DEFAULT_TYPOGRAPHY`; readers who customized keep theirs.
+- **feat(typography): `text-wrap` polish.** Headings get `text-wrap: balance` (no lone short last
+  line), `.prose p` gets `text-wrap: pretty` (better rag) — both progressive, ignored where unsupported.
+- **refactor: removed the last hardcoded public text sizes.** Brand wordmark `text-lg` → `.fs-h4`;
+  Theme/Palette toggle menu items `text-sm` → `.t-small`; `PostCard` excerpt `leading-relaxed` +
+  inline `font-size` → new `.t-body` utility (body role outside `.prose`). Public size grep is now clean.
+
 ## 2026-06-23 (v1.1.0-beta — admin overhaul: dotted canvas, shared UI kit, 5-tab settings)
 - **feat(admin): a shared UI kit ends the per-page drift.** New `components/admin/kit.tsx` is the
   ONE source for admin chrome — `Card` (canonical surface), `PageHeader` (the title block every

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -41,9 +41,14 @@
   `typographyToCss()` into the root layout AFTER `globals.css` (also applies in the admin
   editor `.prose` = WYSIWYG). `smoothing` adds `-webkit-font-smoothing` on `body`.
 - **Where applied:** `.prose` (h1–h5/pre/code/figcaption/table) read the role vars; titles/UI
-  OUTSIDE `.prose` use `.fs-h1…fs-h5` + `.t-small` (every secondary text). H1 = single
-  post/page titles + category/tag headings + draft preview; list cards (`PostCard`) = H2. Only
-  fixed public sizes allowed: the brand wordmark + the 404 numeral.
+  OUTSIDE `.prose` use `.fs-h1…fs-h5` (titles) + `.t-small` (secondary text) + `.t-body`
+  (body-role text outside prose: card excerpts, footer). H1 = single post/page titles +
+  category/tag headings + draft preview; list cards (`PostCard`) = H2; brand wordmark = `.fs-h4`.
+  Only fixed public size left: the 404 numeral.
+- **Reading-optimized defaults (= the Reset target).** Restrained, monotonic heading scale
+  (h1 2.0 → h5 1.0, h5 no longer below body), 18px body at ~1.7 leading, ~66-char measure
+  (`contentWidth` 672). Headings get `text-wrap: balance`, `.prose p` gets `text-wrap: pretty`
+  (both progressive). Change the numbers in BOTH `globals.css :root` and `DEFAULT_TYPOGRAPHY`.
 - **Inter is self-hosted** (`public/fonts/inter-{latin,latin-ext,vietnamese}.woff2`,
   variable, declared via `@font-face` + `unicode-range` in `globals.css`; `--font-inter:'Inter'`
   there). **No `next/font/google`** — it fetched at build, which broke offline/CI builds. The OG

--- a/src/app/(blog)/layout.tsx
+++ b/src/app/(blog)/layout.tsx
@@ -46,7 +46,7 @@ export default async function BlogLayout({ children }: { children: React.ReactNo
                 decoding="async"
               />
             ) : (
-              <span className="text-lg font-bold tracking-tight">{settings.title}</span>
+              <span className="fs-h4 font-bold">{settings.title}</span>
             )}
           </Link>
           <div className="flex shrink-0 items-center gap-0.5">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -72,15 +72,17 @@
      owner's saved values are injected after this file (a :root override via
      typographyToCss) and win. Roles: h1-h5, body, small (meta/dates/UI),
      caption (figures), code (mono). */
-  --fs-h1: 1.95rem;  --lh-h1: 1.2;   --ls-h1: -0.02em;
-  --fs-h2: 1.4rem;   --lh-h2: 1.28;  --ls-h2: -0.015em;
-  --fs-h3: 1.2rem;   --lh-h3: 1.35;  --ls-h3: -0.011em;
+  /* Defaults mirror DEFAULT_TYPOGRAPHY in lib/themes.ts (the no-JS fallback; the
+     owner's saved scale is injected after this by typographyToCss). Keep in sync. */
+  --fs-h1: 2.0rem;   --lh-h1: 1.2;   --ls-h1: -0.02em;
+  --fs-h2: 1.5rem;   --lh-h2: 1.27;  --ls-h2: -0.015em;
+  --fs-h3: 1.25rem;  --lh-h3: 1.35;  --ls-h3: -0.01em;
   --fs-h4: 1.15rem;  --lh-h4: 1.45;  --ls-h4: -0.006em;
-  --fs-h5: 0.9rem;   --lh-h5: 1.5;   --ls-h5: 0em;
-  --fs-body: 1.125rem; --lh-body: 1.75; --ls-body: 0em;
+  --fs-h5: 1.0rem;   --lh-h5: 1.5;   --ls-h5: 0em;
+  --fs-body: 1.125rem; --lh-body: 1.7; --ls-body: 0em;
   --fs-small: 0.875rem; --lh-small: 1.55; --ls-small: 0em;
   --fs-caption: 0.8125rem; --lh-caption: 1.5; --ls-caption: 0.003em;
-  --fs-code: 0.875rem; --lh-code: 1.65; --ls-code: 0em;
+  --fs-code: 0.875rem; --lh-code: 1.6; --ls-code: 0em;
 }
 :where(.dark) {
   --c-bg: #0e0e0f;
@@ -133,9 +135,12 @@ p, h1, h2, h3, h4, li, blockquote, a {
   overflow-wrap: break-word;
 }
 
-/* Heading colour (size/tracking come from the role vars below). */
+/* Heading colour (size/tracking come from the role vars below). `text-wrap:
+   balance` evens out multi-line headings (no lone short last line) — progressive,
+   ignored where unsupported. */
 h1, h2, h3, h4, h5 {
   color: var(--c-heading);
+  text-wrap: balance;
 }
 
 /* Role utilities — apply a role to text OUTSIDE .prose so every size/line/spacing
@@ -148,6 +153,8 @@ h1, h2, h3, h4, h5 {
 .fs-h4 { font-size: var(--fs-h4); line-height: var(--lh-h4); letter-spacing: var(--ls-h4); }
 .fs-h5 { font-size: var(--fs-h5); line-height: var(--lh-h5); letter-spacing: var(--ls-h5); }
 .t-small { font-size: var(--fs-small); line-height: var(--lh-small); letter-spacing: var(--ls-small); }
+/* Body-role text OUTSIDE .prose (excerpts, footer) — same size/rhythm as running text. */
+.t-body { font-size: var(--fs-body); line-height: var(--lh-body); letter-spacing: var(--ls-body); }
 
 /* One divider style for the whole site: faint, 50% wide, left-aligned. */
 hr {
@@ -218,6 +225,8 @@ hr {
 }
 .prose p {
   margin-top: 1.4em;
+  /* Improve the rag and avoid a lone short last line; progressive, safe to ignore. */
+  text-wrap: pretty;
 }
 .prose a {
   color: var(--c-link);

--- a/src/components/blog/PostCard.tsx
+++ b/src/components/blog/PostCard.tsx
@@ -26,7 +26,7 @@ export function PostCard({
           : ''}
       </p>
       {post.excerpt && (
-        <p className="mt-3 leading-relaxed text-text" style={{ fontSize: 'var(--fs-body)' }}>
+        <p className="mt-3 t-body text-text">
           {post.excerpt}
         </p>
       )}

--- a/src/components/theme/PaletteToggle.tsx
+++ b/src/components/theme/PaletteToggle.tsx
@@ -113,7 +113,7 @@ export function PaletteToggle({
                   apply(p.id)
                   setOpen(false)
                 }}
-                className={`flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm hover:bg-rule ${
+                className={`flex w-full items-center gap-2.5 px-3 py-2 text-left t-small hover:bg-rule ${
                   current === p.id ? 'font-semibold text-heading' : 'text-meta'
                 }`}
               >

--- a/src/components/theme/ThemeToggle.tsx
+++ b/src/components/theme/ThemeToggle.tsx
@@ -90,7 +90,7 @@ export function ThemeToggle({
                   setMode(it.key)
                   setOpen(false)
                 }}
-                className={`flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-rule ${
+                className={`flex w-full items-center justify-between px-3 py-2 text-left t-small hover:bg-rule ${
                   mode === it.key ? 'font-semibold text-heading' : 'text-meta'
                 }`}
               >

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -19,19 +19,28 @@ export const TYPE_ROLES: TypeRole[] = ['h1', 'h2', 'h3', 'h4', 'h5', 'body', 'sm
 export const FONT_WEIGHTS = [400, 500, 600, 700] as const
 
 // Default type system (client-safe so the settings UI imports it for reset).
-// Restrained ~1.18 scale off an 18px body: list-card titles (H2) read as headings,
-// single-post/page/category titles step up to H1.
+// Tuned for long-form reading the way fine European book typography is set:
+//  - 18px body (--fs-body 1.125rem) at a ~66-char measure (contentWidth 672) — the
+//    classic 60-75 cpl comfort zone (Bringhurst's ideal ~66).
+//  - Body leading 1.7: airy enough for screens, a touch tighter than the old 1.75
+//    so the column reads as an even grey block rather than spaced-out lines.
+//  - A restrained, monotonic heading scale (h1 2.0 → h5 1.0). Headings stay modest
+//    (books differentiate with weight + whitespace, not size); larger sizes take
+//    tighter leading + a little negative tracking, body/small stay at 0.
+//  - h4 sits just above body; h5 is the small label (was 0.9, below body — fixed).
+// Mirror any change in globals.css :root (the no-JS fallback) AND the table in
+// docs/conventions.md.
 export const DEFAULT_TYPOGRAPHY: TypographySettings = {
   roles: {
-    h1: { size: 1.95, line: 1.2, spacing: -0.02 },
-    h2: { size: 1.4, line: 1.28, spacing: -0.015 },
-    h3: { size: 1.2, line: 1.35, spacing: -0.011 },
+    h1: { size: 2.0, line: 1.2, spacing: -0.02 },
+    h2: { size: 1.5, line: 1.27, spacing: -0.015 },
+    h3: { size: 1.25, line: 1.35, spacing: -0.01 },
     h4: { size: 1.15, line: 1.45, spacing: -0.006 },
-    h5: { size: 0.9, line: 1.5, spacing: 0 },
-    body: { size: 1.125, line: 1.75, spacing: 0 },
+    h5: { size: 1.0, line: 1.5, spacing: 0 },
+    body: { size: 1.125, line: 1.7, spacing: 0 },
     small: { size: 0.875, line: 1.55, spacing: 0 },
     caption: { size: 0.8125, line: 1.5, spacing: 0.003 },
-    code: { size: 0.875, line: 1.65, spacing: 0 },
+    code: { size: 0.875, line: 1.6, spacing: 0 },
   },
   smoothing: false,
 }


### PR DESCRIPTION
## Track C of the motion/footer/typography work

**Reading-optimized defaults** (the Reset target), researched against classic book typesetting:
- Restrained, monotonic heading scale (h1 2.0 → h5 1.0). **h5 was 0.9 (below body) — fixed.**
- Body leading 1.75 → 1.7 (even grey column), code 1.65 → 1.6, h2 1.4 → 1.5 (clearer hierarchy).
- ~66-char measure (`contentWidth` 672) kept — already in the 60–75 cpl comfort zone.
- Mirrored in **both** `globals.css :root` and `DEFAULT_TYPOGRAPHY`. Readers who customized keep their values.

**Polish:** `text-wrap: balance` on headings, `text-wrap: pretty` on `.prose p` (progressive).

**Removed the last hardcoded public text sizes:** wordmark `text-lg` → `.fs-h4`; Theme/Palette toggle items `text-sm` → `.t-small`; `PostCard` excerpt `leading-relaxed`+inline → new `.t-body` utility. Public size grep is clean.

## Verify
- `npm run check:all` ✓ (81 tests) · `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)