### PR TITLE
feat: optimistic comments + route loading skeleton (motion engine A4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # CHANGELOG
 
-## 2026-06-23 (v1.1.0-beta — motion engine: subtle, token-gated, one switch)
+## 2026-06-23 (v1.1.0-beta — instant comments (optimistic) + route loading skeleton)
+- **feat(comments): a posted comment now appears instantly (optimistic).** It's rendered with the
+  SAME `renderCommentMarkdown` the server uses — so there's no content drift — overlaid on the tree
+  via the new, tested `lib/comment-tree.ts` `mergeOptimisticComments`, then the authoritative refetch
+  replaces it and clears the overlay. A failed POST removes the optimistic comment and shows the
+  error. (Supersedes the old "refetch only" note; the refetch is still the source of truth.) The
+  composer + sign-in buttons moved to `CommentForm.tsx` to keep files focused.
+- **feat: a themed loading skeleton for blog routes** (`(blog)/loading.tsx` + `.skeleton`) for
+  instant feedback on navigation. The subtle pulse follows the motion engine (gated by `data-motion`
+  + `prefers-reduced-motion`), so it degrades to a calm static placeholder; sized to roughly match a
+  post so the swap to real content barely shifts. `v1.1.0-beta`.
 - **feat: a site-wide motion engine for a calmer, more "app-like" feel.** ONE set of tokens
   (`--dur-fast/base/slow` + `--ease`) drives every transition/animation across the public site AND
   admin. A single switch gates all of it: `<html data-motion>` is server-rendered from a new

--- a/docs/features.md
+++ b/docs/features.md
@@ -31,7 +31,8 @@
   *sensitive* — accent-insensitivity comes from the local layer only. Header search =
   `SearchOverlay` (modal); the `/search` route stays for deep links / no-JS.
 - Post page: `ReadingProgress`, `BackToTop`, `Toc`, `RelatedPosts` (`getRelatedPosts`: shared
-  tags ×2 + categories).
+  tags ×2 + categories). Blog routes show a themed skeleton while loading (`(blog)/loading.tsx` +
+  `.skeleton`, motion-engine-gated).
 - `Toc` shows whenever a post has headings OR an in-page jump (`showToc` in the page; renders
   nothing otherwise). Header: clickable **"Tiêu đề"** (`tocTitle`) that scrolls to top when there
   ARE headings, else a plain non-clickable **"Mục lục"** (`tocIndex`). One line under it joins the
@@ -141,11 +142,13 @@ manual (name + email + optional website, optionally behind Cloudflare Turnstile)
 Google/Facebook account.
 
 - **Instant, never cached — by design.** The post page stays ISR/static; the comment block is a
-  CLIENT island (`Comments.tsx`) that fetches `/api/comments?post=<slug>` with `no-store`. The
-  route sets `fetchCache = 'force-no-store'` so its DB read is LIVE. A new comment is POSTed, then
-  the island REFETCHES (authoritative, no optimistic reconciliation). **No `revalidatePath` ever
-  runs for a comment** — so commenting never touches the ISR/`revalidate.ts` path. The live count
-  on the page comes from the same fetch, so it can't go stale.
+  CLIENT island (`Comments.tsx`; the composer + sign-in buttons live in `CommentForm.tsx`) that
+  fetches `/api/comments?post=<slug>` with `no-store`. The route sets `fetchCache = 'force-no-store'`
+  so its DB read is LIVE. A new comment is POSTed and shown **optimistically** — rendered with the
+  SAME `renderCommentMarkdown` the server uses (no content drift) and overlaid via
+  `mergeOptimisticComments` (`lib/comment-tree.ts`, tested) — then an authoritative REFETCH replaces
+  it and clears the overlay (a failed POST removes the optimistic comment + shows the error). **No
+  `revalidatePath` ever runs for a comment.** The live count comes from the same fetch + overlay.
 - **Limited markdown (`comment-md.ts`):** only `**bold**` / `*italic*`. The source is HTML-escaped
   FIRST, then only `<strong>/<em>/<br>` are injected — no user tag, link, image, or script survives
   (mirrors Invariant 5). Hard cap 1000 chars (server + client).

--- a/src/app/(blog)/loading.tsx
+++ b/src/app/(blog)/loading.tsx
@@ -1,0 +1,24 @@
+// Shown while a blog route segment loads (instant feedback on navigation). Renders
+// inside the (blog) layout (header + centered column already there), so this is just
+// the inner content placeholder. Themed faint blocks; the pulse follows the motion
+// engine (see `.skeleton` in globals.css). Sized to roughly match a post so the swap
+// to real content barely shifts.
+export default function Loading() {
+  return (
+    <div className="py-4" aria-busy="true" aria-live="polite">
+      {/* Title + meta */}
+      <div className="skeleton h-9 w-3/4" />
+      <div className="skeleton mt-4 h-4 w-40" />
+      {/* Body lines */}
+      <div className="mt-10 space-y-4">
+        <div className="skeleton h-4 w-full" />
+        <div className="skeleton h-4 w-full" />
+        <div className="skeleton h-4 w-11/12" />
+        <div className="skeleton h-4 w-4/5" />
+        <div className="skeleton mt-8 h-4 w-full" />
+        <div className="skeleton h-4 w-full" />
+        <div className="skeleton h-4 w-3/4" />
+      </div>
+    </div>
+  )
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -587,3 +587,20 @@ button:not(:disabled):active,
     transform: none;
   }
 }
+
+/* Loading skeleton block (route loading.tsx). Faint themed surface; the subtle
+   pulse follows the motion engine (gated by data-motion + reduced-motion), so it
+   degrades to a calm static placeholder. */
+.skeleton {
+  background: var(--c-rule);
+  border-radius: 0.375rem;
+}
+@media (prefers-reduced-motion: no-preference) {
+  :root[data-motion='on'] .skeleton {
+    animation: skeleton-pulse 1.4s var(--ease) infinite;
+  }
+}
+@keyframes skeleton-pulse {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}

--- a/src/components/blog/CommentForm.tsx
+++ b/src/components/blog/CommentForm.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+// The comment composer + the OAuth sign-in buttons. Split out of Comments.tsx
+// (the island/tree) to keep each file focused. The parent owns submit/optimistic;
+// this is a controlled form that validates, gates on Turnstile, and reports busy/error.
+import { useCallback, useState } from 'react'
+import { signIn } from 'next-auth/react'
+import type { SiteLang } from '@/types'
+import { t } from '@/lib/i18n'
+import { Turnstile } from './Turnstile'
+
+export const MAX = 1000
+export type Draft = { name: string; email: string; website: string; content: string }
+const EMPTY: Draft = { name: '', email: '', website: '', content: '' }
+
+const inputClass =
+  't-small w-full rounded-lg border border-rule bg-bg px-3 py-2 text-text outline-none focus:border-heading'
+
+export function SignInButton({ label, provider }: { label: string; provider: 'google' | 'facebook' }) {
+  return (
+    <button
+      type="button"
+      onClick={() => signIn(provider, { callbackUrl: window.location.href })}
+      className="t-small rounded-lg border border-rule px-3 py-2 text-text hover:bg-rule"
+    >
+      {label}
+    </button>
+  )
+}
+
+export function CommentForm({
+  lang,
+  onSubmit,
+  turnstile,
+  turnstileSiteKey,
+  viewer = false,
+  autoFocus,
+}: {
+  lang: SiteLang
+  onSubmit: (draft: Draft, token: string | null) => Promise<boolean>
+  turnstile: boolean
+  turnstileSiteKey: string
+  viewer?: boolean
+  autoFocus?: boolean
+}) {
+  const s = t(lang)
+  const [draft, setDraft] = useState<Draft>(EMPTY)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState(false)
+  const [token, setToken] = useState<string | null>(null)
+  const set = (k: keyof Draft, v: string) => setDraft((d) => ({ ...d, [k]: v }))
+  const onToken = useCallback((tk: string | null) => setToken(tk), [])
+
+  // A signed-in viewer needs no identity fields and no Turnstile (the server
+  // trusts the session). Otherwise: name + email, and Turnstile (if on) must be
+  // solved before the content step — identity first so the gate is meaningful.
+  const showWidget = turnstile && !!turnstileSiteKey && !viewer
+  const identityOk = viewer || (!!draft.name.trim() && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(draft.email.trim()))
+  const gateOpen = !showWidget || !!token
+  const valid = identityOk && draft.content.trim() && gateOpen
+
+  async function handle(e: React.FormEvent) {
+    e.preventDefault()
+    if (!valid || busy) return
+    setBusy(true)
+    setError(false)
+    const okied = await onSubmit({ ...draft, content: draft.content.slice(0, MAX) }, token)
+    setBusy(false)
+    if (okied) {
+      setDraft(EMPTY)
+      setToken(null) // tokens are single-use — force a fresh solve for the next one
+    } else {
+      setError(true)
+    }
+  }
+
+  return (
+    <form onSubmit={handle} className="space-y-2.5">
+      {!viewer && (
+        <div className="grid gap-2.5 sm:grid-cols-3">
+          <input
+            className={inputClass}
+            placeholder={s.commentName}
+            value={draft.name}
+            onChange={(e) => set('name', e.target.value)}
+            autoFocus={autoFocus}
+            maxLength={80}
+          />
+          <input
+            className={inputClass}
+            type="email"
+            placeholder={`${s.commentEmail} · ${s.commentEmailNote}`}
+            value={draft.email}
+            onChange={(e) => set('email', e.target.value)}
+            maxLength={120}
+          />
+          <input
+            className={inputClass}
+            placeholder={s.commentWebsite}
+            value={draft.website}
+            onChange={(e) => set('website', e.target.value)}
+          />
+        </div>
+      )}
+
+      {/* Gate: with Turnstile on, the widget appears once identity is filled and
+          must be solved before the comment box is shown. */}
+      {showWidget && !gateOpen ? (
+        identityOk && <Turnstile siteKey={turnstileSiteKey} onToken={onToken} />
+      ) : (
+        <>
+          <textarea
+            className={`${inputClass} min-h-[6rem] resize-y`}
+            placeholder={s.commentBody}
+            value={draft.content}
+            onChange={(e) => set('content', e.target.value.slice(0, MAX))}
+          />
+          <div className="flex items-center justify-between gap-3">
+            <span className="t-small text-meta">
+              {s.commentFormatHint} · {draft.content.length}/{MAX}
+            </span>
+            <button
+              type="submit"
+              disabled={!valid || busy}
+              className="t-small rounded-lg border border-heading bg-heading px-4 py-2 font-medium text-bg transition-opacity disabled:opacity-40"
+            >
+              {busy ? s.commentSubmitting : s.commentSubmit}
+            </button>
+          </div>
+        </>
+      )}
+      {error && <p className="t-small text-meta">{s.commentError}</p>}
+    </form>
+  )
+}

--- a/src/components/blog/Comments.tsx
+++ b/src/components/blog/Comments.tsx
@@ -1,30 +1,26 @@
 'use client'
 
 // Public comment island. The post page stays ISR/static; this fetches the comment
-// tree from /api/comments with `no-store`, so a just-posted comment shows on the
-// next load with NO cache in the way. After a successful post we simply refetch —
-// authoritative + instant, no optimistic reconciliation to get wrong.
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { signIn, signOut } from 'next-auth/react'
+// tree from /api/comments with `no-store`. A just-posted comment shows INSTANTLY
+// (optimistic) using the SAME `renderCommentMarkdown` the server uses — so there is
+// no content drift — then the authoritative refetch replaces it and clears the
+// pending overlay. On failure the optimistic comment is removed + an error shown.
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { signOut } from 'next-auth/react'
 import type { PublicComment, SiteLang } from '@/types'
 import { t, formatDate } from '@/lib/i18n'
-import { Turnstile } from './Turnstile'
+import { renderCommentMarkdown } from '@/lib/comment-md'
+import { mergeOptimisticComments } from '@/lib/comment-tree'
+import { CommentForm, SignInButton, MAX, type Draft } from './CommentForm'
 
 type Viewer = { name: string } | null
 
-const MAX = 1000
 const MAX_DEPTH = 2
-
-type Draft = { name: string; email: string; website: string; content: string }
-const EMPTY: Draft = { name: '', email: '', website: '', content: '' }
 
 // Count real (non-tombstone) comments across the whole tree, for the heading.
 function countVisible(nodes: PublicComment[]): number {
   return nodes.reduce((n, c) => n + (c.deleted ? 0 : 1) + countVisible(c.replies), 0)
 }
-
-const inputClass =
-  't-small w-full rounded-lg border border-rule bg-bg px-3 py-2 text-text outline-none focus:border-heading'
 
 export function Comments({
   postSlug,
@@ -43,10 +39,12 @@ export function Comments({
 }) {
   const s = t(lang)
   const [comments, setComments] = useState<PublicComment[]>([])
+  const [pending, setPending] = useState<PublicComment[]>([])
   const [loaded, setLoaded] = useState(false)
   const [replyTo, setReplyTo] = useState<number | null>(null)
   const [viewer, setViewer] = useState<Viewer>(null)
   const oauthOn = googleAuth || facebookAuth
+  const tempId = useRef(-1) // optimistic ids count down so they never clash with real ones
 
   // Fetch the tree (no setState) so callers decide when to commit it to state —
   // keeps setState out of the synchronous effect body (deferred, after await).
@@ -95,25 +93,48 @@ export function Comments({
     }
   }, [oauthOn])
 
-  // POST a comment; on success refetch the tree and close any reply form.
+  // POST a comment. Show it optimistically (same renderer as the server), then
+  // reconcile with an authoritative refetch and drop the pending overlay. On any
+  // failure, remove the optimistic comment so the form can report the error.
   const submit = useCallback(
     async (parentId: number | null, draft: Draft, token: string | null): Promise<boolean> => {
-      const res = await fetch('/api/comments', {
+      const id = tempId.current--
+      const optimistic: PublicComment = {
+        id,
+        parentId,
+        name: viewer?.name || draft.name.trim(),
+        website: draft.website.trim() || undefined,
+        provider: 'manual',
+        contentHtml: renderCommentMarkdown(draft.content.slice(0, MAX)),
+        createdAt: new Date().toISOString(),
+        deleted: false,
+        replies: [],
+      }
+      setPending((p) => [...p, optimistic])
+      const ok = await fetch('/api/comments', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ postSlug, parentId, ...draft, turnstileToken: token }),
-      }).catch(() => null)
-      if (!res || !res.ok) return false
-      const json = await res.json().catch(() => null)
-      if (!json?.success) return false
-      setComments(await fetchTree())
+      })
+        .then((res) => res.ok && res.json())
+        .then((json) => !!json?.success)
+        .catch(() => false)
+      if (!ok) {
+        setPending((p) => p.filter((c) => c.id !== id))
+        return false
+      }
+      const fresh = await fetchTree()
+      setComments(fresh)
+      setPending((p) => p.filter((c) => c.id !== id))
       setReplyTo(null)
       return true
     },
-    [postSlug, fetchTree],
+    [postSlug, fetchTree, viewer],
   )
 
-  const count = useMemo(() => countVisible(comments), [comments])
+  // Optimistic comments overlaid on the authoritative tree, for render + count.
+  const displayed = useMemo(() => mergeOptimisticComments(comments, pending), [comments, pending])
+  const count = useMemo(() => countVisible(displayed), [displayed])
 
   return (
     <section className="mt-6">
@@ -147,11 +168,11 @@ export function Comments({
         )}
       </div>
 
-      {loaded && comments.length === 0 ? (
+      {loaded && displayed.length === 0 ? (
         <p className="mt-6 t-small text-meta">{s.commentsEmpty}</p>
       ) : (
         <ul className="mt-8 space-y-6">
-          {comments.map((c) => (
+          {displayed.map((c) => (
             <CommentNode
               key={c.id}
               comment={c}
@@ -262,123 +283,5 @@ function CommentNode({
         </ul>
       )}
     </li>
-  )
-}
-
-function SignInButton({ label, provider }: { label: string; provider: 'google' | 'facebook' }) {
-  return (
-    <button
-      type="button"
-      onClick={() => signIn(provider, { callbackUrl: window.location.href })}
-      className="t-small rounded-lg border border-rule px-3 py-2 text-text hover:bg-rule"
-    >
-      {label}
-    </button>
-  )
-}
-
-function CommentForm({
-  lang,
-  onSubmit,
-  turnstile,
-  turnstileSiteKey,
-  viewer = false,
-  autoFocus,
-}: {
-  lang: SiteLang
-  onSubmit: (draft: Draft, token: string | null) => Promise<boolean>
-  turnstile: boolean
-  turnstileSiteKey: string
-  viewer?: boolean
-  autoFocus?: boolean
-}) {
-  const s = t(lang)
-  const [draft, setDraft] = useState<Draft>(EMPTY)
-  const [busy, setBusy] = useState(false)
-  const [error, setError] = useState(false)
-  const [token, setToken] = useState<string | null>(null)
-  const set = (k: keyof Draft, v: string) => setDraft((d) => ({ ...d, [k]: v }))
-  const onToken = useCallback((tk: string | null) => setToken(tk), [])
-
-  // A signed-in viewer needs no identity fields and no Turnstile (the server
-  // trusts the session). Otherwise: name + email, and Turnstile (if on) must be
-  // solved before the content step — identity first so the gate is meaningful.
-  const showWidget = turnstile && !!turnstileSiteKey && !viewer
-  const identityOk = viewer || (!!draft.name.trim() && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(draft.email.trim()))
-  const gateOpen = !showWidget || !!token
-  const valid = identityOk && draft.content.trim() && gateOpen
-
-  async function handle(e: React.FormEvent) {
-    e.preventDefault()
-    if (!valid || busy) return
-    setBusy(true)
-    setError(false)
-    const okied = await onSubmit({ ...draft, content: draft.content.slice(0, MAX) }, token)
-    setBusy(false)
-    if (okied) {
-      setDraft(EMPTY)
-      setToken(null) // tokens are single-use — force a fresh solve for the next one
-    } else {
-      setError(true)
-    }
-  }
-
-  return (
-    <form onSubmit={handle} className="space-y-2.5">
-      {!viewer && (
-        <div className="grid gap-2.5 sm:grid-cols-3">
-          <input
-            className={inputClass}
-            placeholder={s.commentName}
-            value={draft.name}
-            onChange={(e) => set('name', e.target.value)}
-            autoFocus={autoFocus}
-            maxLength={80}
-          />
-          <input
-            className={inputClass}
-            type="email"
-            placeholder={`${s.commentEmail} · ${s.commentEmailNote}`}
-            value={draft.email}
-            onChange={(e) => set('email', e.target.value)}
-            maxLength={120}
-          />
-          <input
-            className={inputClass}
-            placeholder={s.commentWebsite}
-            value={draft.website}
-            onChange={(e) => set('website', e.target.value)}
-          />
-        </div>
-      )}
-
-      {/* Gate: with Turnstile on, the widget appears once identity is filled and
-          must be solved before the comment box is shown. */}
-      {showWidget && !gateOpen ? (
-        identityOk && <Turnstile siteKey={turnstileSiteKey} onToken={onToken} />
-      ) : (
-        <>
-          <textarea
-            className={`${inputClass} min-h-[6rem] resize-y`}
-            placeholder={s.commentBody}
-            value={draft.content}
-            onChange={(e) => set('content', e.target.value.slice(0, MAX))}
-          />
-          <div className="flex items-center justify-between gap-3">
-            <span className="t-small text-meta">
-              {s.commentFormatHint} · {draft.content.length}/{MAX}
-            </span>
-            <button
-              type="submit"
-              disabled={!valid || busy}
-              className="t-small rounded-lg border border-heading bg-heading px-4 py-2 font-medium text-bg transition-opacity disabled:opacity-40"
-            >
-              {busy ? s.commentSubmitting : s.commentSubmit}
-            </button>
-          </div>
-        </>
-      )}
-      {error && <p className="t-small text-meta">{s.commentError}</p>}
-    </form>
   )
 }

--- a/src/lib/comment-tree.test.ts
+++ b/src/lib/comment-tree.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { mergeOptimisticComments } from '@/lib/comment-tree'
+import type { PublicComment } from '@/types'
+
+const node = (id: number, parentId: number | null, replies: PublicComment[] = []): PublicComment => ({
+  id,
+  parentId,
+  name: `c${id}`,
+  provider: 'manual',
+  contentHtml: `<p>${id}</p>`,
+  createdAt: '2026-01-01T00:00:00Z',
+  deleted: false,
+  replies,
+})
+
+describe('mergeOptimisticComments', () => {
+  it('returns the tree unchanged when nothing is pending', () => {
+    const tree = [node(1, null)]
+    expect(mergeOptimisticComments(tree, [])).toBe(tree)
+  })
+
+  it('appends a top-level pending comment to the end of the list', () => {
+    const tree = [node(1, null)]
+    const out = mergeOptimisticComments(tree, [node(-1, null)])
+    expect(out.map((c) => c.id)).toEqual([1, -1])
+  })
+
+  it('appends a pending reply to its parent’s replies (nested)', () => {
+    const tree = [node(1, null, [node(2, 1)])]
+    const out = mergeOptimisticComments(tree, [node(-1, 2)])
+    expect(out[0].replies[0].replies.map((c) => c.id)).toEqual([-1])
+  })
+
+  it('does not mutate the input tree', () => {
+    const tree = [node(1, null)]
+    mergeOptimisticComments(tree, [node(-1, 1)])
+    expect(tree[0].replies).toEqual([])
+  })
+})

--- a/src/lib/comment-tree.ts
+++ b/src/lib/comment-tree.ts
@@ -1,0 +1,15 @@
+// Pure helper for the optimistic comment overlay. The Comments island shows a
+// just-posted comment immediately, then an authoritative refetch replaces it.
+// This merges the pending comments onto the fetched tree for that brief window:
+// top-level pending append to the list; replies append to their parent's replies.
+// Drift-free because the refetch (same renderer) then clears the overlay.
+import type { PublicComment } from '@/types'
+
+export function mergeOptimisticComments(tree: PublicComment[], pending: PublicComment[]): PublicComment[] {
+  if (!pending.length) return tree
+  const tops = pending.filter((p) => p.parentId == null)
+  const childrenOf = (id: number) => pending.filter((p) => p.parentId === id)
+  const walk = (nodes: PublicComment[]): PublicComment[] =>
+    nodes.map((n) => ({ ...n, replies: walk(n.replies).concat(childrenOf(n.id)) }))
+  return walk(tree).concat(tops)
+}


### PR DESCRIPTION
## Track A4 — the last motion-roadmap items

**Optimistic comments** (instant feel, drift-free)
- A posted comment appears immediately, rendered with the **same** `renderCommentMarkdown` the server uses — no content drift.
- Overlaid on the tree via the new, **tested** `lib/comment-tree.ts` `mergeOptimisticComments` (top-level append / nested reply / no-mutate).
- The authoritative refetch then replaces it and clears the overlay; a failed POST removes the optimistic comment and shows the error. Refetch remains the source of truth.
- Composer + sign-in buttons split into `CommentForm.tsx` (keeps `Comments.tsx` under the 400-line cap).

**Route loading skeleton**
- `(blog)/loading.tsx` + `.skeleton` give instant feedback on navigation. The subtle pulse follows the motion engine (gated by `data-motion` + `prefers-reduced-motion`) → degrades to a calm static placeholder; sized to roughly match a post so the swap barely shifts.

## Verify
- `npm run check:all` ✓ (91 tests incl. new `comment-tree.test.ts`; pre-existing ThemeFields warning only) · `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)