### PR TITLE
fix(ui): logo pointer cursor, title wrapping, more visible admin dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
-## 2026-06-23 (v1.1.0-beta — instant comments (optimistic) + route loading skeleton)
+## 2026-06-23 (v1.1.0-beta — UI fixes: logo cursor, title wrapping, admin dots)
+- **fix: the header logo/wordmark now shows the pointer (hand) cursor**, not the text caret
+  (`cursor-pointer` on the brand link).
+- **fix: titles no longer wrap too early.** Dropped `text-wrap: balance` on headings — it shortened
+  lines and left a premature right rag on list-card titles. Body keeps `text-wrap: pretty`.
+- **change: the admin dotted canvas is more visible** in both light and dark (dot opacity + size up).
 - **feat(comments): a posted comment now appears instantly (optimistic).** It's rendered with the
   SAME `renderCommentMarkdown` the server uses — so there's no content drift — overlaid on the tree
   via the new, tested `lib/comment-tree.ts` `mergeOptimisticComments`, then the authoritative refetch

--- a/src/app/(blog)/layout.tsx
+++ b/src/app/(blog)/layout.tsx
@@ -27,7 +27,7 @@ export default async function BlogLayout({ children }: { children: React.ReactNo
             on the logo's vertical midline at any logo size. The description sits
             below the whole row. */}
         <div className="flex items-center justify-between gap-4">
-          <Link href="/" className="inline-flex items-center">
+          <Link href="/" className="inline-flex cursor-pointer items-center">
             {showLogo ? (
               // Plain <img>, NOT next/image: the logo host is owner-configurable at
               // runtime, but next/image's optimizer only allows hosts whitelisted in

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -158,12 +158,11 @@ p, h1, h2, h3, h4, li, blockquote, a {
   overflow-wrap: break-word;
 }
 
-/* Heading colour (size/tracking come from the role vars below). `text-wrap:
-   balance` evens out multi-line headings (no lone short last line) — progressive,
-   ignored where unsupported. */
+/* Heading colour (size/tracking come from the role vars below). No `text-wrap:
+   balance` — it shortened lines and made titles wrap too early (premature rag);
+   headings wrap normally. Body paragraphs still use `text-wrap: pretty` below. */
 h1, h2, h3, h4, h5 {
   color: var(--c-heading);
-  text-wrap: balance;
 }
 
 /* Role utilities — apply a role to text OUTSIDE .prose so every size/line/spacing
@@ -494,13 +493,13 @@ hr {
    the dot colour is a fixed faint neutral per mode (NOT a public theme token). */
 .admin-canvas {
   background-color: #fafafa; /* neutral-50 */
-  background-image: radial-gradient(rgba(0, 0, 0, 0.07) 1px, transparent 1px);
+  background-image: radial-gradient(rgba(0, 0, 0, 0.13) 1.2px, transparent 1.2px);
   background-size: 22px 22px;
   background-position: -1px -1px;
 }
 .dark .admin-canvas {
   background-color: #0a0a0a; /* neutral-950 */
-  background-image: radial-gradient(rgba(255, 255, 255, 0.06) 1px, transparent 1px);
+  background-image: radial-gradient(rgba(255, 255, 255, 0.11) 1.2px, transparent 1.2px);
 }
 
 /* Native colour picker (admin theme): strip the default inner padding/border so


### PR DESCRIPTION
- **Logo cursor**: brand link now shows the pointer (hand), not the text caret (`cursor-pointer`).
- **Title wrapping**: dropped `text-wrap: balance` on headings — it shortened lines and made list-card titles wrap too early (premature right rag). Body keeps `text-wrap: pretty`.
- **Admin dots**: the dotted canvas is more visible in both light + dark (opacity + size up).

`npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)