### PR TITLE
feat(palette): true-neutral Mono, drop Rosé, add Sci-Fi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 2026-06-23 (v1.1.0-beta — palettes: true-neutral Mono, drop Rosé, add Sci-Fi)
+- **fix(palette): Mono is now truly hueless.** The old values had a faint warm/blue cast (cream
+  `bg`/`rule`, slightly blue `text`/`meta`), so the menu hover looked tinted. All pure gray now, and
+  `rule` is a touch lighter so the hover reads as a soft, colourless gray.
+- **change(palette): removed Rosé, added Sci-Fi** — a cool graphite surface with an electric-cyan
+  accent (the deep blue-black + bright cyan dark mode is where it shines). Saved settings migrate
+  cleanly: `sanitizeThemes`/`sanitizeEnabledPalettes` keep only known preset ids, so a stored `rose`
+  is dropped and `scifi` seeded on next save. Names localized in all 6 languages. Still 6 palettes.
+
 ## 2026-06-23 (v1.1.0-beta — UI fixes: logo cursor, title wrapping, admin dots)
 - **fix: the header logo/wordmark now shows the pointer (hand) cursor**, not the text caret
   (`cursor-pointer` on the brand link).

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -48,10 +48,12 @@ export const DEFAULT_TYPOGRAPHY: TypographySettings = {
 // Default typeface: none uploaded → the bundled Inter.
 export const DEFAULT_FONT: FontSettings = { family: '', faces: [] }
 
-// Neutral, almost-hueless grayscale — the vibeblog house style.
+// TRUE neutral grayscale — zero hue, the vibeblog house style. (Earlier values had a
+// faint warm/blue cast: bg/rule read as cream, meta/text leaned blue. All pure gray
+// now; `rule` is a touch lighter so the menu hover reads as a soft, colourless gray.)
 const MONO: ThemeSettings = {
-  light: { bg: '#fbfbfa', text: '#26262b', heading: '#14141a', meta: '#8a8a90', link: '#14141a', rule: '#e9e9e4' },
-  dark: { bg: '#0e0e0f', text: '#d4d4d8', heading: '#f1f1f2', meta: '#85858c', link: '#f1f1f2', rule: '#27272a' },
+  light: { bg: '#fcfcfc', text: '#262626', heading: '#121212', meta: '#8c8c8c', link: '#121212', rule: '#ebebeb' },
+  dark: { bg: '#0e0e0e', text: '#d6d6d6', heading: '#f2f2f2', meta: '#888888', link: '#f2f2f2', rule: '#262626' },
 }
 
 // Warm paper + brown ink — classic long-read comfort, terracotta accent.
@@ -72,10 +74,11 @@ const OCEAN: ThemeSettings = {
   dark: { bg: '#0c121a', text: '#c7d2dd', heading: '#e8eef5', meta: '#7c8a98', link: '#6aa9e0', rule: '#202a36' },
 }
 
-// Soft rose + plum — warm and elegant, raspberry accent.
-const ROSE: ThemeSettings = {
-  light: { bg: '#fbf5f5', text: '#3d2f33', heading: '#2a1f24', meta: '#9c8a90', link: '#b14a63', rule: '#efe0e3' },
-  dark: { bg: '#181113', text: '#ddccd0', heading: '#f3e7ea', meta: '#9d8990', link: '#e08aa0', rule: '#2e2226' },
+// Sci-fi — cool graphite surface with an electric cyan accent. Crisp + techy;
+// the dark mode (deep blue-black + bright cyan) is where it really reads as sci-fi.
+const SCIFI: ThemeSettings = {
+  light: { bg: '#f2f5f7', text: '#1e2a33', heading: '#0d161e', meta: '#74828f', link: '#0e8aa0', rule: '#dce4ea' },
+  dark: { bg: '#0a0f15', text: '#c3d2dc', heading: '#e7f1f7', meta: '#71808c', link: '#36cfe0', rule: '#1b2630' },
 }
 
 // Warm-neutral surface with a vivid amber accent — confident and bright.
@@ -90,7 +93,7 @@ export const THEME_PRESETS: ThemePreset[] = [
   { id: 'sepia', name: 'Sepia', theme: SEPIA },
   { id: 'forest', name: 'Forest', theme: FOREST },
   { id: 'ocean', name: 'Ocean', theme: OCEAN },
-  { id: 'rose', name: 'Rosé', theme: ROSE },
+  { id: 'scifi', name: 'Sci-Fi', theme: SCIFI },
   { id: 'amber', name: 'Amber', theme: AMBER },
 ]
 

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -9,7 +9,7 @@ const de = {
   pageLabel: 'Seite',
   menu: 'Menü',
   palette: 'Farbschema',
-  paletteNames: { mono: 'Mono', sepia: 'Sepia', forest: 'Wald', ocean: 'Ozean', rose: 'Rosé', amber: 'Bernstein' },
+  paletteNames: { mono: 'Mono', sepia: 'Sepia', forest: 'Wald', ocean: 'Ozean', scifi: 'Sci-Fi', amber: 'Bernstein' },
   theme: 'Design',
   themeLight: 'Hell',
   themeDark: 'Dunkel',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -9,7 +9,7 @@ const en = {
   pageLabel: 'Page',
   menu: 'Menu',
   palette: 'Palette',
-  paletteNames: { mono: 'Mono', sepia: 'Sepia', forest: 'Forest', ocean: 'Ocean', rose: 'Rosé', amber: 'Amber' },
+  paletteNames: { mono: 'Mono', sepia: 'Sepia', forest: 'Forest', ocean: 'Ocean', scifi: 'Sci-Fi', amber: 'Amber' },
   theme: 'Theme',
   themeLight: 'Light',
   themeDark: 'Dark',

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -9,7 +9,7 @@ const ja = {
   pageLabel: 'ページ',
   menu: 'メニュー',
   palette: 'パレット',
-  paletteNames: { mono: 'モノ', sepia: 'セピア', forest: 'フォレスト', ocean: 'オーシャン', rose: 'ローズ', amber: 'アンバー' },
+  paletteNames: { mono: 'モノ', sepia: 'セピア', forest: 'フォレスト', ocean: 'オーシャン', scifi: 'サイファイ', amber: 'アンバー' },
   theme: 'テーマ',
   themeLight: 'ライト',
   themeDark: 'ダーク',

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -9,7 +9,7 @@ const ko = {
   pageLabel: '페이지',
   menu: '메뉴',
   palette: '색상',
-  paletteNames: { mono: '모노', sepia: '세피아', forest: '포레스트', ocean: '오션', rose: '로즈', amber: '앰버' },
+  paletteNames: { mono: '모노', sepia: '세피아', forest: '포레스트', ocean: '오션', scifi: '사이파이', amber: '앰버' },
   theme: '테마',
   themeLight: '라이트',
   themeDark: '다크',

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -9,7 +9,7 @@ const vi = {
   pageLabel: 'Trang',
   menu: 'Menu',
   palette: 'Bảng màu',
-  paletteNames: { mono: 'Đơn sắc', sepia: 'Nâu giấy', forest: 'Rừng xanh', ocean: 'Đại dương', rose: 'Hồng phấn', amber: 'Hổ phách' },
+  paletteNames: { mono: 'Đơn sắc', sepia: 'Nâu giấy', forest: 'Rừng xanh', ocean: 'Đại dương', scifi: 'Viễn tưởng', amber: 'Hổ phách' },
   theme: 'Giao diện',
   themeLight: 'Sáng',
   themeDark: 'Tối',

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -9,7 +9,7 @@ const zh = {
   pageLabel: '页',
   menu: '菜单',
   palette: '配色',
-  paletteNames: { mono: '单色', sepia: '棕褐', forest: '森林', ocean: '海洋', rose: '玫瑰', amber: '琥珀' },
+  paletteNames: { mono: '单色', sepia: '棕褐', forest: '森林', ocean: '海洋', scifi: '科幻', amber: '琥珀' },
   theme: '主题',
   themeLight: '浅色',
   themeDark: '深色',


### PR DESCRIPTION
- **Mono is now truly hueless.** Old values had a faint warm/blue cast (cream `bg`/`rule`, slightly blue `text`/`meta`) → the menu hover looked tinted. All pure gray now; `rule` a touch lighter so the hover is a soft, colourless gray.
- **Removed Rosé, added Sci-Fi** — cool graphite surface + electric-cyan accent; the deep blue-black + bright cyan dark mode is where it reads as sci-fi. Distinct from Ocean (blue, editorial).
- **Safe migration:** `sanitizeThemes`/`sanitizeEnabledPalettes` keep only known preset ids, so a stored `rose` drops and `scifi` seeds on next save; `themePreset === 'rose'` falls back to default.
- Names localized in all 6 languages. Still 6 palettes.

`npm run check:all` ✓ (91 tests) · `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)