### PR TITLE
release(v1.1.1): official 1.1 cut + drop text-wrap balance/pretty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v1.1.1 — 2026-06-23 (official release)
+- **First stable cut of the 1.1 line.** Rolls up everything since `v1.1.0-beta`: the admin overhaul
+  (shared UI kit, dotted canvas, 5-tab settings), the reworked post ToC, reader comments incl.
+  optimistic posting + a route loading skeleton, an editable footer with a limited-markdown editor,
+  reading-optimized typography defaults + a reading-time backfill, the site-wide motion engine, and
+  the palette refresh (true-neutral Mono, Sci-Fi replacing Rosé). Detail in the dated entries below.
+- **fix(type): removed `text-wrap: balance`/`pretty`.** Both re-broke whole lines and left too much
+  empty space on the right (titles wrapped early; body looked under-set). Text now wraps normally,
+  filling each line to the measure. Don't reintroduce them.
+
 ## 2026-06-23 (v1.1.0-beta — activity log: errors now recorded + flagged)
 - **feat: the activity log now captures server errors.** `logError` (the central route catch
   handler) schedules `after(() => logActivityError("METHOD /path", message))`, writing an

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# vibe**blog** &nbsp;`v1.1.0-beta`
+# vibe**blog** &nbsp;`v1.1.1`
 
 **An AI-operated personal blog platform.**
 Write and publish from a clean multilingual admin — or hand the keys to an AI agent and let it write, publish, and even deploy for you.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -47,8 +47,8 @@
   Only fixed public size left: the 404 numeral.
 - **Reading-optimized defaults (= the Reset target).** Restrained, monotonic heading scale
   (h1 2.0 → h5 1.0, h5 no longer below body), 18px body at ~1.7 leading, ~66-char measure
-  (`contentWidth` 672). Headings get `text-wrap: balance`, `.prose p` gets `text-wrap: pretty`
-  (both progressive). Change the numbers in BOTH `globals.css :root` and `DEFAULT_TYPOGRAPHY`.
+  (`contentWidth` 672). Text wraps normally (no `text-wrap: balance`/`pretty` — both re-broke lines
+  and left a premature right rag). Change the numbers in BOTH `globals.css :root` and `DEFAULT_TYPOGRAPHY`.
 - **Inter is self-hosted** (`public/fonts/inter-{latin,latin-ext,vietnamese}.woff2`,
   variable, declared via `@font-face` + `unicode-range` in `globals.css`; `--font-inter:'Inter'`
   there). **No `next/font/google`** — it fetched at build, which broke offline/CI builds. The OG

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeblog",
-  "version": "1.1.0-beta",
+  "version": "1.1.1",
   "private": true,
   "license": "MIT",
   "browserslist": [

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -160,7 +160,7 @@ p, h1, h2, h3, h4, li, blockquote, a {
 
 /* Heading colour (size/tracking come from the role vars below). No `text-wrap:
    balance` — it shortened lines and made titles wrap too early (premature rag);
-   headings wrap normally. Body paragraphs still use `text-wrap: pretty` below. */
+   headings (and body paragraphs) wrap normally, filling each line to the measure. */
 h1, h2, h3, h4, h5 {
   color: var(--c-heading);
 }
@@ -258,8 +258,9 @@ hr {
 }
 .prose p {
   margin-top: 1.4em;
-  /* Improve the rag and avoid a lone short last line; progressive, safe to ignore. */
-  text-wrap: pretty;
+  /* No `text-wrap: pretty` — Chromium re-breaks the whole paragraph to even the rag,
+     which shortened lines and left too much space on the right. Normal greedy wrap
+     fills each line to the measure. */
 }
 .prose a {
   color: var(--c-link);


### PR DESCRIPTION
## v1.1.1 — first stable cut of the 1.1 line

Bumps `package.json` + README badge to **v1.1.1** and rolls up everything since the `v1.1.0-beta` prerelease: admin overhaul (UI kit, dotted canvas, 5-tab settings), the reworked post ToC, reader comments incl. **optimistic posting** + a route loading skeleton, an **editable footer** with a limited-markdown editor, **reading-optimized typography defaults** + a reading-time backfill, the site-wide **motion engine**, and the **palette refresh** (true-neutral Mono, Sci-Fi replacing Rosé).

**Also fixes** the reported right-margin issue: removed `text-wrap: balance` (headings) and `text-wrap: pretty` (`.prose p`) — both re-broke whole lines and left too much empty space on the right. Text now wraps normally, filling each line to the measure.

`npm run check:all` ✓ (91 tests) · `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)