### PR TITLE
Docker self-host needs no cloud: bundled Postgres + PostgREST (v1.1.3)

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -22,12 +22,21 @@ AUTH_GOOGLE_SECRET=
 # Only this account email can access /admin. Everyone else is sent home.
 AUTHORIZED_EMAIL=you@example.com
 
-# --- Database (Supabase) ---
-# Project API URL and the SECRET service_role key (Supabase → Project Settings →
-# API). Text content lives in Postgres; binaries are on the local /app/uploads
-# volume. All app access is server-side via service_role.
-SUPABASE_URL=
+# --- Database (bundled Postgres + PostgREST — NO cloud) ---
+# The compose stack ships its own Postgres + PostgREST, so there is no Supabase
+# signup. Generate these three with:  node scripts/docker/gen-keys.mjs >> .env.docker
+#   POSTGRES_PASSWORD          superuser password for the local Postgres
+#   SUPABASE_JWT_SECRET        HS256 secret PostgREST verifies tokens with
+#   SUPABASE_SERVICE_ROLE_KEY  the app's JWT (role=service_role), signed with the secret
+# (compose sets SUPABASE_URL=http://rest:3000 + POSTGREST_DIRECT=1 for you.)
+POSTGRES_PASSWORD=
+SUPABASE_JWT_SECRET=
 SUPABASE_SERVICE_ROLE_KEY=
+#
+# Prefer a MANAGED database instead? Point at any Supabase project (or external
+# PostgREST) by setting SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY here and removing
+# the `db` + `rest` services from docker-compose.yml (leave POSTGREST_DIRECT unset).
+# SUPABASE_URL=
 
 # --- Cron ---
 # Protects /api/cron and authenticates the cron sidecar (keep-alive + variant /

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -109,6 +109,16 @@ can change (e.g. → Cloudflare R2) without rewriting anything.
   Vercel SDK contained so a self-host build can't silently depend on it. **One codebase, no fork:**
   Vercel ignores the `Dockerfile`; the image needs no backend env to build (the data layer
   degrades to empty), so the same source ships both targets.
+- **Bundled DB on self-host, supabase-js unchanged.** Supabase's API is just **PostgREST** over
+  Postgres, and the app uses nothing else from Supabase (no Auth/Realtime/Storage — sign-in is
+  NextAuth, binaries are the storage driver). So the Docker stack bundles **Postgres + PostgREST**
+  and supabase-js talks to the local PostgREST — the whole data layer is identical, no rewrite to a
+  raw Postgres client. The single seam is in `db.ts`: when `POSTGREST_DIRECT=1` the custom `dbFetch`
+  strips the `/rest/v1` path prefix supabase-js adds (bare PostgREST serves tables at `/`), which
+  avoids a proxy container. Postgres applies `scripts/schema.sql` + a role/grant bootstrap on first
+  init; `service_role` is `BYPASSRLS` (every table has RLS on with no policies, exactly like
+  Supabase). Net: a self-hoster needs **no cloud account** — text in a local Postgres volume,
+  binaries on a local disk volume.
 - **100% Markdown, raw HTML escaped** → safe, portable content; videos are bare URLs
   embedded at render, not stored iframes.
 - **Responsive images, encoding deferred to save** → jpg/png uploads keep the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+## v1.1.3 — 2026-06-23
+- **feat: Docker self-host needs NO cloud — bundled Postgres + PostgREST.** The compose stack now
+  ships its own database, so a self-hoster never signs up for Supabase. Because the app only ever
+  uses Supabase's REST layer (no Supabase Auth/Realtime/Storage), the stack is just **Postgres +
+  PostgREST** (2 light containers): supabase-js points at the local PostgREST and the **entire data
+  layer stays byte-for-byte unchanged**. The only code change is 3 env-gated lines in `db.ts` —
+  when `POSTGREST_DIRECT=1` it strips the `/rest/v1` path prefix so supabase-js reaches bare
+  PostgREST (no proxy container). Postgres applies `scripts/schema.sql` + a role/grant bootstrap
+  (`docker/initdb/`) on first boot; `scripts/docker/gen-keys.mjs` mints the DB password + JWT secret
+  + `service_role` key. Text now lives in `./data/postgres`, binaries in `./data/uploads` — back up
+  those two folders. Managed-DB users can still point `SUPABASE_URL` at a real Supabase and drop the
+  `db`/`rest` services. **Vercel is unchanged** (no `POSTGREST_DIRECT` → hits Supabase as before).
+
 ## v1.1.2 — 2026-06-23
 - **feat: Docker self-host, from the same codebase.** `src/lib/blob.ts` is now a storage facade
   with two drivers picked by `STORAGE_DRIVER`: `vercel-blob` (unchanged default) and `local`

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -73,8 +73,13 @@
 - [ ] Toggle OFF (or disconnect) → the cron no longer creates snapshots
 
 ## Docker self-host (only when shipping the image)
-- [ ] `docker compose up -d --build` boots; the image builds with **no backend env** (data layer
-  degrades to empty), then runs with `.env.docker` supplied
+- [ ] `node scripts/docker/gen-keys.mjs >> .env.docker` then `docker compose --env-file .env.docker
+  up -d --build` boots the full no-cloud stack (app + db + rest + cron); image builds with **no
+  backend env**
+- [ ] First boot applies `scripts/schema.sql` + `docker/initdb` roles/grants; `service_role` JWT
+  reaches every table (sign in, create/list a post) — no PostgREST permission errors in `rest` logs
+- [ ] Text survives a restart: `docker compose down && up -d` keeps posts (volume `./data/postgres`)
+- [ ] Analytics dashboard loads (the `analytics_summary`/`analytics_totals` RPCs resolve via PostgREST)
 - [ ] `STORAGE_DRIVER=local`: uploading an image writes under the `/app/uploads` volume and renders
   at `/uploads/...` (original + thumb + variants); it survives `docker compose down && up`
 - [ ] Large upload (>4.5 MB) succeeds — the browser posts to `/api/media/upload` (no serverless cap)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,9 @@ BEFORE reading code** (live, needs `.env.local`; skips cleanly without creds). R
 
 ## Architecture (operational)
 
-- **Text in Supabase Postgres; binaries via the `blob.ts` storage driver** (Vercel Blob by
-  default, local filesystem on Docker/self-host — `STORAGE_DRIVER`). Tables (schema `public`):
+- **Text in Postgres (Supabase on Vercel; a bundled Postgres+PostgREST on Docker — supabase-js
+  unchanged, see Env); binaries via the `blob.ts` storage driver** (Vercel Blob by default, local
+  filesystem on Docker/self-host — `STORAGE_DRIVER`). Tables (schema `public`):
   `posts` `pages` `post_revisions` `media` `files` `settings` `mcp_tokens`
   `backup_state` `activity_log` `analytics_events` `analytics_scroll` — full DDL in
   `scripts/schema.sql`; data-model shapes + the *why* in ARCHITECTURE.md.
@@ -66,8 +67,11 @@ BEFORE reading code** (live, needs `.env.local`; skips cleanly without creds). R
   token — `.env.local` + Vercel only. MCP enabled + tokenized from the admin (no `MCP_TOKEN`
   env); optional `MCP_OAUTH_SECRET` signs OAuth codes (falls back to `AUTH_SECRET`).
   **Self-host (Docker):** `STORAGE_DRIVER=local` + `NEXT_PUBLIC_STORAGE_DRIVER=local` (baked into
-  the image) + `STORAGE_LOCAL_DIR` (volume) + `SITE_URL`; no Blob token. Full set in
-  `.env.docker.example`; build needs no backend env (data layer degrades to empty).
+  the image) + `STORAGE_LOCAL_DIR` (volume) + `SITE_URL`; no Blob token. **No Supabase cloud** — the
+  stack bundles Postgres + PostgREST; `db.ts` strips the `/rest/v1` prefix when `POSTGREST_DIRECT=1`
+  so supabase-js hits the local PostgREST unchanged (`SUPABASE_URL=http://rest:3000`, key from
+  `scripts/docker/gen-keys.mjs`; roles/grants in `docker/initdb/`). Full set in `.env.docker.example`;
+  build needs no backend env (data layer degrades to empty).
 - **Region:** `vercel.json` pins functions + the Blob store to `sin1` (Singapore); OG is edge.
   Detail → `docs/seo-pwa.md`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# vibe**blog** &nbsp;`v1.1.2`
+# vibe**blog** &nbsp;`v1.1.3`
 
 **An AI-operated personal blog platform.**
 Write and publish from a clean multilingual admin — or hand the keys to an AI agent and let it write, publish, and even deploy for you.
@@ -33,7 +33,7 @@ Write and publish from a clean multilingual admin — or hand the keys to an AI 
 
 An **open-source** (MIT), single-owner blog built for people who just want to **write**. The public site is statically cached so it loads **insanely fast on mobile and desktop**, and it's tuned around **readable typography** — a clean reading experience first. Everything is **easy to tweak from the admin** (palettes, type, menu, fonts) with **no hardcoded values** anywhere, so you make it yours without touching code.
 
-All the writing happens in a polished `/admin` (or over MCP). Text lives in **Supabase Postgres**; binaries (images, files, icons) go through a pluggable storage driver — **Vercel Blob** by default, or the **local filesystem** when you self-host with Docker. No git push to publish, no CMS to wrangle.
+All the writing happens in a polished `/admin` (or over MCP). Text lives in **Postgres** (Supabase on Vercel, or a bundled Postgres when you self-host); binaries (images, files, icons) go through a pluggable storage driver — **Vercel Blob** by default, or the **local filesystem** on Docker. No git push to publish, no CMS to wrangle.
 
 | Area | What you get |
 |:---|:---|
@@ -47,7 +47,7 @@ All the writing happens in a polished `/admin` (or over MCP). Text lives in **Su
 | 🤖&nbsp;**MCP** | a remote endpoint that lets an AI agent write & manage the blog with the same rules as the admin |
 | 📱&nbsp;**PWA** | installable, launches standalone |
 | 🔐&nbsp;**Auth** | NextAuth v5 · Google sign-in · single authorized owner · edge-guarded admin/API |
-| 🚀&nbsp;**Deploy** | Vercel + Supabase (+ Vercel Blob), **or** self-host with Docker (local filesystem storage) — same codebase |
+| 🚀&nbsp;**Deploy** | Vercel + Supabase (+ Vercel Blob), **or** self-host with Docker — bundled Postgres + local storage, **no cloud** — same codebase |
 
 > Built on **Next.js 16** (App Router, React 19, strict TS) + **Tailwind v4**, deployed on **Vercel** or self-hosted with **Docker**.
 
@@ -110,15 +110,17 @@ Deploy my own copy of github.com/joiha-steven/vibeblog:
 
 <br/>
 
-Runs the Next standalone server as a plain container. **No Vercel Blob** — binaries use the local filesystem driver and live in a mounted volume (`./data/uploads`); back that folder up next to your Postgres dump. Postgres (Supabase or self-hosted Supabase) and Google OAuth stay external, same as the Vercel path.
+**Fully self-contained — no cloud accounts.** The stack bundles **Postgres + PostgREST** (replaces Supabase) and the **local filesystem** store (replaces Vercel Blob), plus a cron sidecar. Everything runs on your host; only Google sign-in reaches the internet. Data lives in `./data/postgres` (text) + `./data/uploads` (binaries) — back up those two folders.
 
 ```bash
 git clone https://github.com/joiha-steven/vibeblog.git && cd vibeblog
-cp .env.docker.example .env.docker   # fill in Supabase, AUTH_*, SITE_URL, CRON_SECRET
-docker compose up -d --build         # app on :3000 + an hourly cron sidecar
+cp .env.docker.example .env.docker
+node scripts/docker/gen-keys.mjs >> .env.docker   # DB password + JWT secret + service key
+# then fill AUTH_SECRET, AUTH_GOOGLE_ID/SECRET, AUTHORIZED_EMAIL, SITE_URL, CRON_SECRET
+docker compose --env-file .env.docker up -d --build   # app on :3000 + db + rest + cron
 ```
 
-Then point a reverse proxy / TLS at port `3000`, and register `<SITE_URL>/api/auth/callback/google` (and `<SITE_URL>/api/backup/callback` for Drive backups) on your Google OAuth client. The image needs **no backend env to build** — env is supplied at runtime via `.env.docker`. Storage is selected by `STORAGE_DRIVER=local` (baked into the image); the Vercel path keeps using Blob unchanged.
+Then point a reverse proxy / TLS at port `3000`, and register `<SITE_URL>/api/auth/callback/google` (and `<SITE_URL>/api/backup/callback` for Drive backups) on your Google OAuth client. The image needs **no backend env to build** — secrets are supplied at runtime. The bundled DB applies `scripts/schema.sql` automatically on first boot. Prefer a managed database? Point `SUPABASE_URL` at any Supabase project and drop the `db`/`rest` services — see [`.env.docker.example`](./.env.docker.example). The Vercel path is unchanged (Supabase + Blob).
 
 </details>
 
@@ -154,8 +156,9 @@ See [`.env.example`](./.env.example). The essentials:
 | `AUTH_SECRET` | ✅ | NextAuth secret — generate with `npx auth secret` |
 | `AUTHORIZED_EMAIL` | ✅ | The only email allowed into `/admin` — your email |
 | `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` | ✅ | Google OAuth "Web" client (admin sign-in + optional commenter login) — [Cloud Console → Credentials](https://console.cloud.google.com/apis/credentials) |
-| `SUPABASE_URL` | ✅ | Supabase project API URL — Supabase → Settings → API |
-| `SUPABASE_SERVICE_ROLE_KEY` | ✅ | Supabase `service_role` key (secret, server-only) — same page |
+| `SUPABASE_URL` | ✅ | Supabase project API URL — Supabase → Settings → API. **Docker:** auto-set to the bundled PostgREST (`http://rest:3000`) |
+| `SUPABASE_SERVICE_ROLE_KEY` | ✅ | Supabase `service_role` key (secret, server-only) — same page. **Docker:** generate with `node scripts/docker/gen-keys.mjs` |
+| `POSTGRES_PASSWORD` / `SUPABASE_JWT_SECRET` | ◻️ Docker | Bundled-DB secrets for the local Postgres + PostgREST — produced by `gen-keys.mjs` alongside the key above |
 | `BLOB_READ_WRITE_TOKEN` | ✅ Vercel | Vercel Blob token — **auto-injected** when you connect a Blob store; also derives the public Blob URL. **Not used on Docker** (local filesystem driver) |
 | `STORAGE_DRIVER` | ◻️ Docker | `vercel-blob` (default) or `local`. The Docker image bakes in `local`; binaries go to `STORAGE_LOCAL_DIR` (default `/app/uploads`) |
 | `SITE_URL` | ◻️ Docker | Canonical public URL of the instance (Vercel infers this automatically). Used for OG/sitemap/auth callbacks when self-hosting |
@@ -163,7 +166,7 @@ See [`.env.example`](./.env.example). The essentials:
 | `MCP_OAUTH_SECRET` | ◻️ optional | Signs MCP OAuth codes — random; falls back to `AUTH_SECRET` |
 | Turnstile / Facebook keys | ◻️ optional | Comment anti-spam (Cloudflare Turnstile) + Facebook commenter login — **enter these in Admin → Settings** (stored server-side). The matching env vars (`TURNSTILE_*`, `AUTH_FACEBOOK_*`) still work as a fallback |
 
-MCP tokens and the Google Drive backup connection are **created in the admin**, not via env. Secrets stay in `.env.local` (gitignored) + Vercel (`vercel env pull`) — or `.env.docker` when self-hosting; your blog content lives in Supabase + Blob (or the local volume), never in git. The full self-host set is in [`.env.docker.example`](./.env.docker.example).
+MCP tokens and the Google Drive backup connection are **created in the admin**, not via env. Secrets stay in `.env.local` (gitignored) + Vercel (`vercel env pull`) — or `.env.docker` when self-hosting; your blog content lives in Supabase + Blob (or the bundled Postgres + local volume on Docker), never in git. The full self-host set is in [`.env.docker.example`](./.env.docker.example).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,8 @@ Everything else already ports to a plain Node/Docker runtime:
 - `sharp` does all image work (runs natively on Node — no Vercel image service).
 - ISR + `revalidatePath`, the OG route, NextAuth and Markdown (gray-matter) all run
   under `next start` / standalone output.
-- Text content lives in **Supabase Postgres** (any Postgres works for self-host);
+- Text content lives in **Postgres via PostgREST** — the app uses only Supabase's REST
+  layer, so self-host bundles **Postgres + PostgREST** and supabase-js is unchanged;
   binaries are store-relative on Blob (`collapseBlob`/`expandBlob`), so swapping the
   binary backend is mostly resolving a different base URL.
 
@@ -68,10 +69,13 @@ serves files via `app/uploads/[...path]/route.ts`. `scripts/checks/no-direct-blo
 keeps the SDK contained so a self-host build can't silently reach Vercel Blob. The S3
 driver later reused per-tenant in the SaaS as "bring your own bucket" (Phase 7).
 
-### Phase 2 — Docker `[shipped — local FS driver]`
-- `output: 'standalone'` + `Dockerfile` + `docker-compose.yml` (app + cron sidecar). ✅
+### Phase 2 — Docker `[shipped — no-cloud stack]`
+- `output: 'standalone'` + `Dockerfile` + `docker-compose.yml` (app + db + rest + cron). ✅
   The image builds with **no backend env** (data layer degrades to empty), so it is
   portable; env is supplied at runtime via `.env.docker`.
+- **No cloud:** bundled **Postgres + PostgREST** (replaces Supabase) + local FS store
+  (replaces Blob). supabase-js unchanged — `db.ts` strips the `/rest/v1` prefix when
+  `POSTGREST_DIRECT=1`. `scripts/docker/gen-keys.mjs` mints DB password + JWT. ✅
 - Cron: a sidecar pings `/api/cron` hourly (Vercel Cron has no off-platform equivalent). ✅
 - *Still planned:* a GitHub Action that builds + publishes a versioned image to GHCR on
   each release tag, so updating is `docker compose pull && up -d`; optional bundled MinIO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,74 @@
-# Self-host vibeblog: the Next standalone app + a tiny cron sidecar (Vercel Cron
-# does not exist off-platform). Postgres (Supabase) and Google OAuth stay external
-# — set them in .env.docker (copy .env.docker.example). Binaries persist in
-# ./data/uploads; back that folder up alongside your Postgres dump.
+# Fully self-contained vibeblog — NO cloud. Postgres + PostgREST replace Supabase,
+# the local filesystem replaces Vercel Blob, a cron sidecar replaces Vercel Cron.
+# Everything runs on your own host; only Google OAuth (sign-in) reaches the internet.
 #
-#   cp .env.docker.example .env.docker   # then fill it in
-#   docker compose up -d --build
+#   cp .env.docker.example .env.docker
+#   node scripts/docker/gen-keys.mjs >> .env.docker   # DB password + JWT secret + key
+#   # then fill AUTH_*, SITE_URL, AUTHORIZED_EMAIL in .env.docker
+#   docker compose --env-file .env.docker up -d --build
+#
+# The --env-file flag is required: compose reads it for ${...} substitution below
+# (PostgREST's DB URI + JWT secret), AND each service loads it as container env.
 
 services:
+  # Postgres — the database (was Supabase). Schema + roles are applied once on first
+  # init from docker/initdb + the app's own scripts/schema.sql (single source).
+  db:
+    image: postgres:16-alpine
+    env_file: .env.docker
+    environment:
+      POSTGRES_DB: vibeblog
+      POSTGRES_USER: postgres
+      # POSTGRES_PASSWORD comes from .env.docker (run gen-keys.mjs)
+    volumes:
+      - ./data/postgres:/var/lib/postgresql/data
+      - ./docker/initdb/01_roles.sql:/docker-entrypoint-initdb.d/01_roles.sql:ro
+      - ./scripts/schema.sql:/docker-entrypoint-initdb.d/02_schema.sql:ro
+      - ./docker/initdb/03_grants.sql:/docker-entrypoint-initdb.d/03_grants.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d vibeblog"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    restart: unless-stopped
+
+  # PostgREST — the REST layer supabase-js talks to (was Supabase's API gateway).
+  # Connects as the superuser (db port is NOT exposed to the host) and SET ROLEs to
+  # the role named in each request's JWT (service_role) or `anon` when there is none.
+  rest:
+    image: postgrest/postgrest:v12.2.3
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PGRST_DB_URI: postgres://postgres:${POSTGRES_PASSWORD}@db:5432/vibeblog
+      PGRST_DB_SCHEMAS: public
+      PGRST_DB_ANON_ROLE: anon
+      PGRST_JWT_SECRET: ${SUPABASE_JWT_SECRET}
+    restart: unless-stopped
+
+  # The Next.js app. SUPABASE_URL points at the bundled PostgREST; POSTGREST_DIRECT
+  # makes db.ts strip the `/rest/v1` path prefix so supabase-js works unchanged.
   app:
     build: .
     image: vibeblog
+    depends_on:
+      db:
+        condition: service_healthy
+      rest:
+        condition: service_started
     env_file: .env.docker
+    environment:
+      SUPABASE_URL: http://rest:3000
+      POSTGREST_DIRECT: "1"
     ports:
       - "3000:3000"
     volumes:
       - ./data/uploads:/app/uploads
     restart: unless-stopped
 
-  # Hourly maintenance ping (keep-alive + variant/backup sweep) — the same job
-  # vercel.json runs on Vercel. Calls /api/cron with the CRON_SECRET bearer.
+  # Hourly maintenance ping (variant/backup sweep) — the job vercel.json runs on
+  # Vercel. Calls /api/cron with the CRON_SECRET bearer.
   cron:
     image: alpine:3.20
     depends_on:

--- a/docker/initdb/01_roles.sql
+++ b/docker/initdb/01_roles.sql
@@ -1,0 +1,11 @@
+-- Self-host Postgres bootstrap (runs once, on first DB init, BEFORE the schema).
+-- Recreates the two Supabase roles the app + PostgREST rely on:
+--   anon         — the no-JWT role PostgREST falls back to; granted nothing, so an
+--                  unauthenticated request can reach no data.
+--   service_role — the app's role (carried in the SUPABASE_SERVICE_ROLE_KEY JWT).
+--                  BYPASSRLS mirrors Supabase: every table has RLS enabled with no
+--                  policies, and the app reaches them only by bypassing it.
+-- PostgREST connects as the superuser and SET ROLEs to whichever the JWT names.
+
+create role anon nologin;
+create role service_role nologin bypassrls;

--- a/docker/initdb/03_grants.sql
+++ b/docker/initdb/03_grants.sql
@@ -1,0 +1,14 @@
+-- Runs AFTER the schema (02_schema.sql). Grants service_role the table/function
+-- privileges it needs (RLS is bypassed by the role, but privileges are still
+-- checked). anon stays empty on purpose — no JWT must see nothing.
+grant usage on schema public to anon, service_role;
+
+grant all on all tables in schema public to service_role;
+grant all on all sequences in schema public to service_role;
+grant execute on all functions in schema public to service_role;
+
+-- Cover anything added later in the same session/owner (e.g. future migrations run
+-- as this owner) without a re-grant.
+alter default privileges in schema public grant all on tables to service_role;
+alter default privileges in schema public grant all on sequences to service_role;
+alter default privileges in schema public grant execute on functions to service_role;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeblog",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "license": "MIT",
   "browserslist": [

--- a/scripts/docker/gen-keys.mjs
+++ b/scripts/docker/gen-keys.mjs
@@ -1,0 +1,32 @@
+// Generate the secrets for the bundled (no-cloud) Docker stack:
+//   - POSTGRES_PASSWORD          — the superuser password for the local Postgres
+//   - SUPABASE_JWT_SECRET        — HS256 secret PostgREST verifies tokens with
+//   - SUPABASE_SERVICE_ROLE_KEY  — a JWT (role=service_role) the app authenticates with
+// The JWT is signed with SUPABASE_JWT_SECRET, so the two MUST stay paired.
+// Usage:  node scripts/docker/gen-keys.mjs >> .env.docker   (then fill the rest)
+import { createHmac, randomBytes } from 'node:crypto'
+
+const b64url = (buf) => Buffer.from(buf).toString('base64url')
+const segment = (obj) => b64url(JSON.stringify(obj))
+
+// PostgREST requires the HS256 secret to be at least 32 chars.
+const jwtSecret = randomBytes(48).toString('base64url')
+const pgPassword = randomBytes(18).toString('base64url')
+
+function sign(payload) {
+  const header = segment({ alg: 'HS256', typ: 'JWT' })
+  const body = segment({ ...payload, iat: Math.floor(Date.now() / 1000) })
+  const data = `${header}.${body}`
+  const sig = createHmac('sha256', jwtSecret).update(data).digest('base64url')
+  return `${data}.${sig}`
+}
+
+process.stdout.write(
+  [
+    '# --- bundled-stack secrets (generated; keep private) ---',
+    `POSTGRES_PASSWORD=${pgPassword}`,
+    `SUPABASE_JWT_SECRET=${jwtSecret}`,
+    `SUPABASE_SERVICE_ROLE_KEY=${sign({ role: 'service_role', iss: 'vibeblog' })}`,
+    '',
+  ].join('\n'),
+)

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -23,12 +23,26 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 // - WRITES (POST/PATCH/DELETE/etc.) are `no-store` — never cached.
 export const DB_TAG = 'db'
 const REVALIDATE = 3600
+
+// Self-host (Docker) talks to a BUNDLED PostgREST instead of Supabase's gateway.
+// supabase-js builds `${SUPABASE_URL}/rest/v1/<table>`; bare PostgREST serves tables
+// at `/<table>`, so when POSTGREST_DIRECT=1 we strip the `/rest/v1` prefix here. This
+// keeps the whole data layer (and supabase-js) byte-for-byte identical on both
+// targets — only the URL path differs. Unset on Vercel → hits Supabase unchanged.
+const POSTGREST_DIRECT = process.env.POSTGREST_DIRECT === '1'
+function restTarget(input: RequestInfo | URL): RequestInfo | URL {
+  if (!POSTGREST_DIRECT) return input
+  const url = typeof input === 'string' ? input : input instanceof URL ? input.href : null
+  return url ? url.replace('/rest/v1', '') : input
+}
+
 function dbFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const target = restTarget(input)
   const method = (init?.method ?? 'GET').toUpperCase()
   if (method === 'GET' || method === 'HEAD') {
-    return fetch(input, { ...init, next: { revalidate: REVALIDATE, tags: [DB_TAG] } })
+    return fetch(target, { ...init, next: { revalidate: REVALIDATE, tags: [DB_TAG] } })
   }
-  return fetch(input, { ...init, cache: 'no-store' })
+  return fetch(target, { ...init, cache: 'no-store' })
 }
 
 let _client: SupabaseClient | undefined


### PR DESCRIPTION
## Why

Self-hosting on a VPS but still requiring a **Supabase cloud** signup made no sense. This bundles the database into the Docker stack so a self-hoster needs **no cloud account at all**.

## How (key insight)

Supabase's API is just **PostgREST over Postgres**, and the app uses nothing else from Supabase (sign-in is NextAuth, binaries are the storage driver — no Auth/Realtime/Storage). So the Docker stack bundles **Postgres + PostgREST** and supabase-js points at the local PostgREST. **The entire data layer is byte-for-byte unchanged.**

The only code change is **3 env-gated lines in `db.ts`**: when `POSTGREST_DIRECT=1`, `dbFetch` strips the `/rest/v1` path prefix that supabase-js adds (bare PostgREST serves tables at `/`), which avoids needing a proxy container. Unset on Vercel → hits Supabase exactly as before.

## What's added

- **docker-compose**: `db` (`postgres:16-alpine`, applies `scripts/schema.sql` + role/grant bootstrap on first init, healthcheck) + `rest` (`postgrest:v12.2.3`); `app` wired to `http://rest:3000`.
- **docker/initdb**: `anon` + `service_role` (`BYPASSRLS`, mirrors Supabase RLS-on-no-policies) + grants.
- **scripts/docker/gen-keys.mjs**: mints `POSTGRES_PASSWORD` + `SUPABASE_JWT_SECRET` + a signed `service_role` JWT.
- **.env.docker.example**: bundled-DB default; managed-DB (point at real Supabase, drop `db`/`rest`) documented.

Run: `node scripts/docker/gen-keys.mjs >> .env.docker` then `docker compose --env-file .env.docker up -d --build`.

## Data safety

Text → `./data/postgres`, binaries → `./data/uploads`. Both are host folders, so `compose pull`/restart/reinstall never lose data.

## Verification

- `npm run check:all` green (typecheck + lint + 5 checks + 91 tests); `npx next build` exit 0.
- compose YAML validated (4 services, deps, mounts); `gen-keys.mjs` JWT signature + `role=service_role` verified.
- **Note:** the running stack needs a real Docker host to smoke-test end-to-end (Docker not available in this env) — code/config verified, boot test is on the deployer.

Docs updated: README (no-cloud Docker block + env table), ARCHITECTURE, CLAUDE, CHANGELOG, ROADMAP (Phase 2 = no-cloud), CHECKLIST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)