### PR TITLE
Harden no-cloud Docker stack via end-to-end boot test (v1.1.4)

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -24,14 +24,12 @@ AUTHORIZED_EMAIL=you@example.com
 
 # --- Database (bundled Postgres + PostgREST — NO cloud) ---
 # The compose stack ships its own Postgres + PostgREST, so there is no Supabase
-# signup. Generate these three with:  node scripts/docker/gen-keys.mjs >> .env.docker
-#   POSTGRES_PASSWORD          superuser password for the local Postgres
-#   SUPABASE_JWT_SECRET        HS256 secret PostgREST verifies tokens with
-#   SUPABASE_SERVICE_ROLE_KEY  the app's JWT (role=service_role), signed with the secret
-# (compose sets SUPABASE_URL=http://rest:3000 + POSTGREST_DIRECT=1 for you.)
-POSTGRES_PASSWORD=
-SUPABASE_JWT_SECRET=
-SUPABASE_SERVICE_ROLE_KEY=
+# signup. Do NOT add the keys here — APPEND them once (avoids duplicate keys):
+#     node scripts/docker/gen-keys.mjs >> .env.docker
+# That writes POSTGRES_PASSWORD + PGPASSWORD (local Postgres superuser, same value),
+# PGRST_JWT_SECRET (the HS256 secret PostgREST verifies with), and
+# SUPABASE_SERVICE_ROLE_KEY (the app's JWT, role=service_role, signed with that secret).
+# Compose sets SUPABASE_URL=http://rest:3000 + POSTGREST_DIRECT=1 for you.
 #
 # Prefer a MANAGED database instead? Point at any Supabase project (or external
 # PostgREST) by setting SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY here and removing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # CHANGELOG
 
+## v1.1.4 — 2026-06-23
+- **fix: the no-cloud Docker stack, hardened by a real end-to-end boot test.** Brought the full
+  `docker compose` stack up and fixed three issues a build-only check missed:
+  - **No more `--env-file` footgun.** The compose file no longer uses `${...}` interpolation, so a
+    plain `docker compose up -d` (or any compose command) reads every value straight from
+    `.env.docker` — previously, forgetting `--env-file` silently recreated PostgREST with a blank
+    JWT secret and broke auth. `gen-keys.mjs` now emits `PGPASSWORD` + `PGRST_JWT_SECRET` (the names
+    PostgREST/libpq read directly); the DB URI carries no password.
+  - **ISR cache is writable.** The runner now `mkdir`s + `chown`s `/app/.next/cache` for the `node`
+    user — the standalone image ships `.next/static` as root but never `.next/cache`, so the first
+    request hit `EACCES` trying to write the incremental cache.
+  - **No duplicate env keys.** `.env.docker.example` dropped its empty `POSTGRES_PASSWORD=` /
+    secret placeholders, so `gen-keys.mjs >> .env.docker` appends exactly one of each.
+  Verified live: `service_role` SELECT → 200 and INSERT → 201, `anon` write → 401, the app homepage
+  renders through supabase-js → bundled PostgREST, and `docker compose` runs warning-free.
+
 ## v1.1.3 — 2026-06-23
 - **feat: Docker self-host needs NO cloud — bundled Postgres + PostgREST.** The compose stack now
   ships its own database, so a self-hoster never signs up for Supabase. Because the app only ever

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -73,9 +73,9 @@
 - [ ] Toggle OFF (or disconnect) → the cron no longer creates snapshots
 
 ## Docker self-host (only when shipping the image)
-- [ ] `node scripts/docker/gen-keys.mjs >> .env.docker` then `docker compose --env-file .env.docker
-  up -d --build` boots the full no-cloud stack (app + db + rest + cron); image builds with **no
-  backend env**
+- [ ] `node scripts/docker/gen-keys.mjs >> .env.docker` then `docker compose up -d --build` boots
+  the full no-cloud stack (app + db + rest + cron); image builds with **no backend env**, and no
+  compose `${...}` interpolation warnings appear (every value is read from `.env.docker`)
 - [ ] First boot applies `scripts/schema.sql` + `docker/initdb` roles/grants; `service_role` JWT
   reaches every table (sign in, create/list a post) — no PostgREST permission errors in `rest` logs
 - [ ] Text survives a restart: `docker compose down && up -d` keeps posts (volume `./data/postgres`)

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,10 @@ COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public
 
-# Persisted binary store; owned by the unprivileged node user the server runs as.
-RUN mkdir -p /app/uploads && chown -R node:node /app/uploads
+# Writable dirs for the unprivileged node user: the binary store, and the ISR
+# incremental cache (standalone copies .next/static as root, but never ships
+# .next/cache — Next creates it at runtime and must be able to write there).
+RUN mkdir -p /app/uploads /app/.next/cache && chown -R node:node /app/uploads /app/.next/cache
 USER node
 
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# vibe**blog** &nbsp;`v1.1.3`
+# vibe**blog** &nbsp;`v1.1.4`
 
 **An AI-operated personal blog platform.**
 Write and publish from a clean multilingual admin — or hand the keys to an AI agent and let it write, publish, and even deploy for you.
@@ -117,7 +117,7 @@ git clone https://github.com/joiha-steven/vibeblog.git && cd vibeblog
 cp .env.docker.example .env.docker
 node scripts/docker/gen-keys.mjs >> .env.docker   # DB password + JWT secret + service key
 # then fill AUTH_SECRET, AUTH_GOOGLE_ID/SECRET, AUTHORIZED_EMAIL, SITE_URL, CRON_SECRET
-docker compose --env-file .env.docker up -d --build   # app on :3000 + db + rest + cron
+docker compose up -d --build   # app on :3000 + db + rest + cron
 ```
 
 Then point a reverse proxy / TLS at port `3000`, and register `<SITE_URL>/api/auth/callback/google` (and `<SITE_URL>/api/backup/callback` for Drive backups) on your Google OAuth client. The image needs **no backend env to build** — secrets are supplied at runtime. The bundled DB applies `scripts/schema.sql` automatically on first boot. Prefer a managed database? Point `SUPABASE_URL` at any Supabase project and drop the `db`/`rest` services — see [`.env.docker.example`](./.env.docker.example). The Vercel path is unchanged (Supabase + Blob).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,21 +5,20 @@
 #   cp .env.docker.example .env.docker
 #   node scripts/docker/gen-keys.mjs >> .env.docker   # DB password + JWT secret + key
 #   # then fill AUTH_*, SITE_URL, AUTHORIZED_EMAIL in .env.docker
-#   docker compose --env-file .env.docker up -d --build
+#   docker compose up -d --build
 #
-# The --env-file flag is required: compose reads it for ${...} substitution below
-# (PostgREST's DB URI + JWT secret), AND each service loads it as container env.
+# No ${...} interpolation is used — every value is read straight from .env.docker by
+# the containers — so plain `docker compose <cmd>` works with no --env-file flag.
 
 services:
   # Postgres — the database (was Supabase). Schema + roles are applied once on first
   # init from docker/initdb + the app's own scripts/schema.sql (single source).
   db:
     image: postgres:16-alpine
-    env_file: .env.docker
+    env_file: .env.docker            # POSTGRES_PASSWORD (from gen-keys.mjs)
     environment:
       POSTGRES_DB: vibeblog
       POSTGRES_USER: postgres
-      # POSTGRES_PASSWORD comes from .env.docker (run gen-keys.mjs)
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
       - ./docker/initdb/01_roles.sql:/docker-entrypoint-initdb.d/01_roles.sql:ro
@@ -33,18 +32,19 @@ services:
     restart: unless-stopped
 
   # PostgREST — the REST layer supabase-js talks to (was Supabase's API gateway).
-  # Connects as the superuser (db port is NOT exposed to the host) and SET ROLEs to
-  # the role named in each request's JWT (service_role) or `anon` when there is none.
+  # Reads PGRST_JWT_SECRET + PGPASSWORD straight from .env.docker; connects as the
+  # superuser (db port is NOT exposed to the host) and SET ROLEs to the role named in
+  # each request's JWT (service_role) or `anon` when there is none.
   rest:
     image: postgrest/postgrest:v12.2.3
     depends_on:
       db:
         condition: service_healthy
+    env_file: .env.docker            # PGRST_JWT_SECRET + PGPASSWORD (from gen-keys.mjs)
     environment:
-      PGRST_DB_URI: postgres://postgres:${POSTGRES_PASSWORD}@db:5432/vibeblog
+      PGRST_DB_URI: postgres://postgres@db:5432/vibeblog   # password via PGPASSWORD
       PGRST_DB_SCHEMAS: public
       PGRST_DB_ANON_ROLE: anon
-      PGRST_JWT_SECRET: ${SUPABASE_JWT_SECRET}
     restart: unless-stopped
 
   # The Next.js app. SUPABASE_URL points at the bundled PostgREST; POSTGREST_DIRECT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeblog",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": true,
   "license": "MIT",
   "browserslist": [

--- a/scripts/docker/gen-keys.mjs
+++ b/scripts/docker/gen-keys.mjs
@@ -1,9 +1,12 @@
-// Generate the secrets for the bundled (no-cloud) Docker stack:
-//   - POSTGRES_PASSWORD          — the superuser password for the local Postgres
-//   - SUPABASE_JWT_SECRET        — HS256 secret PostgREST verifies tokens with
-//   - SUPABASE_SERVICE_ROLE_KEY  — a JWT (role=service_role) the app authenticates with
-// The JWT is signed with SUPABASE_JWT_SECRET, so the two MUST stay paired.
-// Usage:  node scripts/docker/gen-keys.mjs >> .env.docker   (then fill the rest)
+// Generate the secrets for the bundled (no-cloud) Docker stack. Every value is
+// consumed DIRECTLY by a container's env (no compose ${...} interpolation), so
+// plain `docker compose up -d` works — no --env-file flag, nothing to break.
+//   POSTGRES_PASSWORD          superuser password Postgres sets on first init
+//   PGPASSWORD                 same value, so PostgREST's libpq can connect
+//   PGRST_JWT_SECRET           HS256 secret PostgREST verifies tokens with
+//   SUPABASE_SERVICE_ROLE_KEY  the app's JWT (role=service_role), signed with it
+// PGRST_JWT_SECRET and the JWT MUST stay paired (the JWT is signed with it).
+// Usage:  node scripts/docker/gen-keys.mjs >> .env.docker
 import { createHmac, randomBytes } from 'node:crypto'
 
 const b64url = (buf) => Buffer.from(buf).toString('base64url')
@@ -25,7 +28,8 @@ process.stdout.write(
   [
     '# --- bundled-stack secrets (generated; keep private) ---',
     `POSTGRES_PASSWORD=${pgPassword}`,
-    `SUPABASE_JWT_SECRET=${jwtSecret}`,
+    `PGPASSWORD=${pgPassword}`,
+    `PGRST_JWT_SECRET=${jwtSecret}`,
     `SUPABASE_SERVICE_ROLE_KEY=${sign({ role: 'service_role', iss: 'vibeblog' })}`,
     '',
   ].join('\n'),


### PR DESCRIPTION
Booted the full `docker compose` stack on a real host (the v1.1.3 PR was verified at build/config level only — Docker wasn't available then). It works, and the boot test surfaced **three real bugs**, all fixed here:

## Fixes

1. **`--env-file` footgun removed.** Compose no longer uses `${...}` interpolation — every value is read straight from `.env.docker`, so a plain `docker compose up -d` (or any compose command) works with no flag. Previously, forgetting `--env-file` silently recreated PostgREST with a **blank** `PGRST_JWT_SECRET` → all requests fell back to `anon` → auth broke. `gen-keys.mjs` now emits `PGPASSWORD` + `PGRST_JWT_SECRET` (the names libpq/PostgREST read directly); the DB URI carries no password.
2. **ISR cache `EACCES`.** The runner now `mkdir`s + `chown`s `/app/.next/cache` for the `node` user — standalone ships `.next/static` as root but never `.next/cache`, so the first request failed to write the incremental cache.
3. **Duplicate env keys.** `.env.docker.example` dropped its empty placeholder lines, so `gen-keys.mjs >> .env.docker` appends exactly one of each.

## Verified live (full stack up)

- `service_role` JWT: **SELECT → 200**, **INSERT → 201**
- `anon` (no token) write → **401** (denied)
- App homepage **200** through supabase-js → bundled PostgREST (the `/rest/v1` strip)
- DB init applied schema + roles/grants; RPCs (`analytics_*`) loaded
- `docker compose` runs **warning-free**, no `--env-file` needed
- ISR cache writes succeed (no `EACCES`)

`npm run check:all` green (91 tests). No app source changed — fixes are in Dockerfile, compose, gen-keys, and the env example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)