### PR TITLE
fix(toc): drop the comment count from the in-page meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v1.1.6 — 2026-06-23
+- **In-page ToC meta drops the comment count.** The label is just `Comments` (`Tags / Categories /
+  Comments`), no number — the count lived on the ISR-cached page so it was always stale; the
+  authoritative count is in `/admin/comments`.
+
 ## v1.1.5 — 2026-06-23
 - **Admin Comments table reworked.** The content cell now clamps to two lines and click-toggles to
   the full comment (click again to collapse) — per row, so replies (flat rows) expand independently.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# vibe**blog** &nbsp;`v1.1.5`
+# vibe**blog** &nbsp;`v1.1.6`
 
 **An AI-operated personal blog platform.**
 Write and publish from a clean multilingual admin — or hand the keys to an AI agent and let it write, publish, and even deploy for you.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeblog",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "private": true,
   "license": "MIT",
   "browserslist": [

--- a/src/app/(blog)/[slug]/page.tsx
+++ b/src/app/(blog)/[slug]/page.tsx
@@ -21,7 +21,6 @@ import { ScrollDepth } from '@/components/blog/ScrollDepth'
 import { RelatedPosts } from '@/components/blog/RelatedPosts'
 import { Comments } from '@/components/blog/Comments'
 import { getCommentEnv } from '@/lib/comment-env'
-import { countsByPosts } from '@/lib/comments'
 import { ogImageUrl } from '@/lib/og'
 import { isPublicallyVisible, readingMinutes, extractHeadings, extractImageUrls } from '@/lib/utils'
 
@@ -106,14 +105,12 @@ export default async function EntryPage({ params }: PageProps<'/[slug]'>) {
     const hasTaxo = post.tags.length > 0 || post.categories.length > 0
     const showComments = Boolean(settings.comments.enabled && commentEnv)
     // ONE in-page jump under the ToC headings: the present section labels joined
-    // (Tags / Categories / Comments (N)), scrolling to the first section that exists.
-    // The comment count is server-rendered (count as of this render).
+    // (Tags / Categories / Comments), scrolling to the first section that exists.
     const tx = t(language)
-    const commentCount = showComments ? (await countsByPosts())[post.slug] ?? 0 : 0
     const metaParts = [
       post.tags.length > 0 ? tx.tagLabel : null,
       post.categories.length > 0 ? tx.categoryLabel : null,
-      showComments ? (commentCount > 0 ? `${tx.commentsHeading} (${commentCount})` : tx.commentsHeading) : null,
+      showComments ? tx.commentsHeading : null,
     ].filter((p): p is string => p !== null)
     const metaAnchor = post.tags.length > 0
       ? TOC_ANCHORS.tags


### PR DESCRIPTION
Removes the `(N)` comment count from the in-page ToC meta line. It lived on the ISR-cached post page so it was always stale; the authoritative count is in `/admin/comments`. The label is now just `Comments` (`Tags / Categories / Comments`), no number. Drops the now-unused `countsByPosts` import from the post page.

Follow-up to #51 per owner request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)