### PR TITLE
chore(admin): denser dotted-grid background, tuned dot opacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.1.7 — 2026-06-23
+- **Admin dotted-grid background tuned.** ~30% denser dots (tile `22px` → `15px`); light dots a touch
+  dimmer (`0.13` → `0.11`), dark dots a touch clearer (`0.11` → `0.12`).
+
 ## v1.1.6 — 2026-06-23
 - **In-page ToC meta drops the comment count.** The label is just `Comments` (`Tags / Categories /
   Comments`), no number — the count lived on the ISR-cached page so it was always stale; the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# vibe**blog** &nbsp;`v1.1.6`
+# vibe**blog** &nbsp;`v1.1.7`
 
 **An AI-operated personal blog platform.**
 Write and publish from a clean multilingual admin — or hand the keys to an AI agent and let it write, publish, and even deploy for you.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeblog",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "private": true,
   "license": "MIT",
   "browserslist": [

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -494,13 +494,13 @@ hr {
    the dot colour is a fixed faint neutral per mode (NOT a public theme token). */
 .admin-canvas {
   background-color: #fafafa; /* neutral-50 */
-  background-image: radial-gradient(rgba(0, 0, 0, 0.13) 1.2px, transparent 1.2px);
-  background-size: 22px 22px;
+  background-image: radial-gradient(rgba(0, 0, 0, 0.11) 1.2px, transparent 1.2px);
+  background-size: 15px 15px;
   background-position: -1px -1px;
 }
 .dark .admin-canvas {
   background-color: #0a0a0a; /* neutral-950 */
-  background-image: radial-gradient(rgba(255, 255, 255, 0.11) 1.2px, transparent 1.2px);
+  background-image: radial-gradient(rgba(255, 255, 255, 0.12) 1.2px, transparent 1.2px);
 }
 
 /* Native colour picker (admin theme): strip the default inner padding/border so


### PR DESCRIPTION
Per owner request on the admin canvas dots:
- ~30% denser (tile `22px` → `15px`)
- light: dots a touch dimmer (`0.13` → `0.11`)
- dark: dots a touch clearer (`0.11` → `0.12`)

CSS-only (`.admin-canvas` in `globals.css`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)