### PR TITLE
chore(admin): start dotted-grid one full gap in from the top-left edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.1.8 — 2026-06-23
+- **Admin dotted-grid starts cleanly from the top-left edge** — one full gap of clear space before the
+  first dot (`background-position` `-1px -1px` → `7.5px 7.5px`), no more dot crammed into the corner.
+
 ## v1.1.7 — 2026-06-23
 - **Admin dotted-grid background tuned.** ~30% denser dots (tile `22px` → `15px`); light dots a touch
   dimmer (`0.13` → `0.11`), dark dots a touch clearer (`0.11` → `0.12`).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# vibe**blog** &nbsp;`v1.1.7`
+# vibe**blog** &nbsp;`v1.1.8`
 
 **An AI-operated personal blog platform.**
 Write and publish from a clean multilingual admin — or hand the keys to an AI agent and let it write, publish, and even deploy for you.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeblog",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "private": true,
   "license": "MIT",
   "browserslist": [

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -496,7 +496,9 @@ hr {
   background-color: #fafafa; /* neutral-50 */
   background-image: radial-gradient(rgba(0, 0, 0, 0.11) 1.2px, transparent 1.2px);
   background-size: 15px 15px;
-  background-position: -1px -1px;
+  /* Origin at the top-left edge, one full gap of clear space, then the first dot
+     (dots are tile-centred, so +7.5px lands the first dot one 15px gap in). */
+  background-position: 7.5px 7.5px;
 }
 .dark .admin-canvas {
   background-color: #0a0a0a; /* neutral-950 */


### PR DESCRIPTION
Per owner: the admin canvas dots should read **edge → gap → first dot** from the top/left, instead of a dot crammed into the corner.

`background-position` `-1px -1px` → `7.5px 7.5px` (dots are tile-centred, so +7.5px lands the first dot one 15px gap in). CSS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)